### PR TITLE
Schema Validation and UX improvements

### DIFF
--- a/pythx/__init__.py
+++ b/pythx/__init__.py
@@ -10,8 +10,6 @@ from pythx.api.client import Client
 from pythx.models.exceptions import (
     PythXBaseException,
     PythXAPIError,
-    RequestDecodeError,
     RequestValidationError,
-    ResponseDecodeError,
     ResponseValidationError,
 )

--- a/pythx/api/client.py
+++ b/pythx/api/client.py
@@ -181,6 +181,7 @@ class Client:
 
     def __enter__(self):
         self.assert_authentication()
+        return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.logout()

--- a/pythx/api/client.py
+++ b/pythx/api/client.py
@@ -178,3 +178,9 @@ class Client:
             assert_authentication=False,
             include_auth_header=False,
         )
+
+    def __enter__(self):
+        self.assert_authentication()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.logout()

--- a/pythx/api/client.py
+++ b/pythx/api/client.py
@@ -143,7 +143,7 @@ class Client:
             solc_version=solc_version,
             analysis_mode=analysis_mode,
         )
-        req.validate()
+        # req.validate()
         return self._assemble_send_parse(req, respmodels.AnalysisSubmissionResponse)
 
     def status(self, uuid: str) -> respmodels.AnalysisStatusResponse:

--- a/pythx/api/client.py
+++ b/pythx/api/client.py
@@ -77,7 +77,7 @@ class Client:
             LOGGER.debug("Access and refresh token have expired - logging in again")
             self.login()
 
-    def login(self):
+    def login(self) -> respmodels.AuthLoginResponse:
         req = reqmodels.AuthLoginRequest(
             eth_address=self.eth_address, password=self.password
         )
@@ -91,14 +91,14 @@ class Client:
         self.refresh_token = resp_model.refresh_token
         return resp_model
 
-    def logout(self):
+    def logout(self) -> respmodels.AuthLogoutResponse:
         req = reqmodels.AuthLogoutRequest()
         resp_model = self._assemble_send_parse(req, respmodels.AuthLogoutResponse)
         self.access_token = None
         self.refresh_token = None
         return resp_model
 
-    def refresh(self, assert_authentication=True):
+    def refresh(self, assert_authentication=True) -> respmodels.AuthRefreshResponse:
         req = reqmodels.AuthRefreshRequest(
             access_token=self.access_token, refresh_token=self.refresh_token
         )
@@ -112,9 +112,9 @@ class Client:
         self.refresh_token = resp_model.refresh_token
         return resp_model
 
-    def analysis_list(
+    def analysis_list (
         self, date_from: datetime = None, date_to: datetime = None, offset: int = None
-    ):
+    ) -> respmodels.AnalysisListResponse:
         req = reqmodels.AnalysisListRequest(
             offset=offset, date_from=date_from, date_to=date_to
         )
@@ -131,7 +131,7 @@ class Client:
         source_list: List[str] = None,
         solc_version: str = None,
         analysis_mode: str = "quick",
-    ):
+    ) -> respmodels.AnalysisSubmissionResponse:
         req = reqmodels.AnalysisSubmissionRequest(
             contract_name=contract_name,
             bytecode=bytecode,
@@ -146,22 +146,22 @@ class Client:
         req.validate()
         return self._assemble_send_parse(req, respmodels.AnalysisSubmissionResponse)
 
-    def status(self, uuid: str):
+    def status(self, uuid: str) -> respmodels.AnalysisStatusResponse:
         req = reqmodels.AnalysisStatusRequest(uuid)
         return self._assemble_send_parse(req, respmodels.AnalysisStatusResponse)
 
-    def analysis_ready(self, uuid: str):
+    def analysis_ready(self, uuid: str) -> bool:
         resp = self.status(uuid)
         return (
             resp.analysis.status == respmodels.AnalysisStatus.FINISHED
             or resp.analysis.status == respmodels.AnalysisStatus.ERROR
         )
 
-    def report(self, uuid: str):
+    def report(self, uuid: str) -> respmodels.DetectedIssuesResponse:
         req = reqmodels.DetectedIssuesRequest(uuid)
         return self._assemble_send_parse(req, respmodels.DetectedIssuesResponse)
 
-    def openapi(self, mode="yaml"):
+    def openapi(self, mode="yaml") -> respmodels.OASResponse:
         req = reqmodels.OASRequest(mode=mode)
         return self._assemble_send_parse(
             req,
@@ -170,7 +170,7 @@ class Client:
             include_auth_header=False,
         )
 
-    def version(self):
+    def version(self) -> respmodels.VersionResponse:
         req = reqmodels.VersionRequest()
         return self._assemble_send_parse(
             req,

--- a/pythx/api/client.py
+++ b/pythx/api/client.py
@@ -112,7 +112,7 @@ class Client:
         self.refresh_token = resp_model.refresh_token
         return resp_model
 
-    def analysis_list (
+    def analysis_list(
         self, date_from: datetime = None, date_to: datetime = None, offset: int = None
     ) -> respmodels.AnalysisListResponse:
         req = reqmodels.AnalysisListRequest(

--- a/pythx/api/handler.py
+++ b/pythx/api/handler.py
@@ -62,11 +62,13 @@ class APIHandler:
 
     def execute_request_middlewares(self, req):
         for mw in self.middlewares:
+            LOGGER.debug("Executing request middleware: %s", mw)
             req = mw.process_request(req)
         return req
 
     def execute_response_middlewares(self, resp):
         for mw in self.middlewares:
+            LOGGER.debug("Executing response middleware: %s", mw)
             resp = mw.process_response(resp)
         return resp
 

--- a/pythx/cli/main.py
+++ b/pythx/cli/main.py
@@ -5,19 +5,17 @@ import os
 import sys
 import tempfile
 import time
+from collections import defaultdict
+from copy import copy
+from distutils import spawn
 from os import environ, path
 from pprint import pprint
-from collections import defaultdict
-from distutils import spawn
 from subprocess import check_output
-from copy import copy
-import tempfile
 
 import click
 from tabulate import tabulate
 
 from pythx.api import Client
-
 
 if environ.get("PYTHX_DEBUG") is not None:
     logging.basicConfig(level=logging.DEBUG)
@@ -74,7 +72,7 @@ solc_path_opt = click.option(
     "--solc-path",
     type=click.Path(exists=True),
     default=None,
-    help="Path to the solc compiler"
+    help="Path to the solc compiler",
 )
 uuid_arg = click.argument("uuid", type=click.UUID)
 
@@ -182,9 +180,7 @@ def compile_from_source(source_path: str, solc_path: str = None):
     solc_path = spawn.find_executable("solc") if solc_path is None else solc_path
     if solc_path is None:
         # user solc path invalid or no default "solc" command found
-        click.echo(
-            "Invalid solc path. Please make sure solc is on your PATH."
-        )
+        click.echo("Invalid solc path. Please make sure solc is on your PATH.")
         sys.exit(1)
     solc_command = [
         solc_path,
@@ -314,10 +310,7 @@ def check(config, staging, bytecode_file, source_file, solc_path):
     elif source_file:
         with open(source_file, "r") as source_f:
             source_content = source_f.read().strip()
-        compiled = compile_from_source(
-            source_file,
-            solc_path=solc_path
-        )
+        compiled = compile_from_source(source_file, solc_path=solc_path)
         if len(compiled["contracts"]) > 1:
             click.echo(
                 (

--- a/pythx/config/base.py
+++ b/pythx/config/base.py
@@ -7,4 +7,3 @@ class PythXConfig(dict):
             "production": "https://api.mythx.io/",
             "staging": "https://staging.api.mythx.io/",
         }
-        self["timeouts"] = {"access": 600, "refresh": 3600}  # 10m  # 1h

--- a/pythx/models/exceptions.py
+++ b/pythx/models/exceptions.py
@@ -2,15 +2,7 @@ class PythXBaseException(Exception):
     pass
 
 
-class ResponseDecodeError(PythXBaseException):
-    pass
-
-
 class ResponseValidationError(PythXBaseException):
-    pass
-
-
-class RequestDecodeError(PythXBaseException):
     pass
 
 

--- a/pythx/models/request/analysis_list.py
+++ b/pythx/models/request/analysis_list.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 
 import dateutil.parser
 
-from pythx.models.exceptions import RequestDecodeError, RequestValidationError
+from pythx.models.exceptions import RequestValidationError
 from pythx.models.request.base import BaseRequest
 from pythx.models.util import dict_delete_none_fields
 
@@ -40,7 +40,7 @@ class AnalysisListRequest(BaseRequest):
     @classmethod
     def from_dict(cls, d: Dict[str, Any]):
         if not all(k in d for k in ANALYSIS_LIST_KEYS):
-            raise RequestDecodeError(
+            raise RequestValidationError(
                 "Not all required keys {} found in data {}".format(
                     ANALYSIS_LIST_KEYS, d
                 )

--- a/pythx/models/request/analysis_list.py
+++ b/pythx/models/request/analysis_list.py
@@ -37,9 +37,6 @@ class AnalysisListRequest(BaseRequest):
     def payload(self):
         return {}
 
-    def validate(self):
-        return (self.date_from <= self.date_to) and self.offset >= 0
-
     @classmethod
     def from_dict(cls, d: Dict[str, Any]):
         if not all(k in d for k in ANALYSIS_LIST_KEYS):

--- a/pythx/models/request/analysis_status.py
+++ b/pythx/models/request/analysis_status.py
@@ -33,9 +33,6 @@ class AnalysisStatusRequest(BaseRequest):
     def payload(self):
         return {}
 
-    def validate(self):
-        pass
-
     @classmethod
     def from_dict(cls, d):
         uuid = d.get("uuid")

--- a/pythx/models/request/analysis_status.py
+++ b/pythx/models/request/analysis_status.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 
 import dateutil.parser
 
-from pythx.models.exceptions import RequestDecodeError, RequestValidationError
+from pythx.models.exceptions import RequestValidationError
 from pythx.models.request.base import BaseRequest
 from pythx.models.util import dict_delete_none_fields
 

--- a/pythx/models/request/analysis_status.py
+++ b/pythx/models/request/analysis_status.py
@@ -37,7 +37,7 @@ class AnalysisStatusRequest(BaseRequest):
     def from_dict(cls, d):
         uuid = d.get("uuid")
         if uuid is None:
-            raise RequestDecodeError("Missing uuid field in data {}".format(d))
+            raise RequestValidationError("Missing uuid field in data {}".format(d))
         return cls(uuid=uuid)
 
     def to_dict(self):

--- a/pythx/models/request/analysis_submission.py
+++ b/pythx/models/request/analysis_submission.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger(__name__)
 
 class AnalysisSubmissionRequest(BaseRequest):
     with open(resolve_schema(__file__, "analysis-submission.json")) as sf:
-            schema = json.load(sf)
+        schema = json.load(sf)
 
     def __init__(
         self,
@@ -74,16 +74,18 @@ class AnalysisSubmissionRequest(BaseRequest):
         )
 
     def to_dict(self):
-        base_dict = dict_delete_none_fields({
-            "contractName": self.contract_name,
-            "bytecode": self.bytecode,
-            "sourceMap": self.source_map,
-            "deployedBytecode": self.deployed_bytecode,
-            "deployedSourceMap": self.deployed_source_map,
-            "sources": self.sources if self.sources else None,
-            "sourceList": self.source_list if self.source_list else None,
-            "version": self.solc_version,
-            "analysisMode": self.analysis_mode,
-        })
+        base_dict = dict_delete_none_fields(
+            {
+                "contractName": self.contract_name,
+                "bytecode": self.bytecode,
+                "sourceMap": self.source_map,
+                "deployedBytecode": self.deployed_bytecode,
+                "deployedSourceMap": self.deployed_source_map,
+                "sources": self.sources if self.sources else None,
+                "sourceList": self.source_list if self.source_list else None,
+                "version": self.solc_version,
+                "analysisMode": self.analysis_mode,
+            }
+        )
         self.validate(base_dict)
         return base_dict

--- a/pythx/models/request/analysis_submission.py
+++ b/pythx/models/request/analysis_submission.py
@@ -56,20 +56,20 @@ class AnalysisSubmissionRequest(BaseRequest):
     def payload(self):
         return {"data": self.to_dict()}
 
-    def validate(self):
-        LOGGER.debug("Validating %s", self.to_dict())
-        valid = True
-        msg = "Error validating analysis submission request: {}"
-        if self.analysis_mode not in ("full", "quick"):
-            valid = False
-            msg = msg.format("Analysis mode must be one of {full,quick}")
-        elif not (self.bytecode or self.sources):
-            valid = False
-            msg = msg.format("Must pass at least bytecode or source field")
-        # TODO: MOAR
+    # def validate(self):
+    #     LOGGER.debug("Validating %s", self.to_dict())
+    #     valid = True
+    #     msg = "Error validating analysis submission request: {}"
+    #     if self.analysis_mode not in ("full", "quick"):
+    #         valid = False
+    #         msg = msg.format("Analysis mode must be one of {full,quick}")
+    #     elif not (self.bytecode or self.sources):
+    #         valid = False
+    #         msg = msg.format("Must pass at least bytecode or source field")
+    #     # TODO: MOAR
 
-        if not valid:
-            raise RequestValidationError(msg)
+    #     if not valid:
+    #         raise RequestValidationError(msg)
 
     @classmethod
     def from_dict(cls, d: Dict):
@@ -80,7 +80,6 @@ class AnalysisSubmissionRequest(BaseRequest):
                 )
             )
 
-        # TODO: Should we validate here?
         return cls(
             contract_name=d.get("contractName"),
             bytecode=d.get("bytecode"),

--- a/pythx/models/request/auth_login.py
+++ b/pythx/models/request/auth_login.py
@@ -36,9 +36,6 @@ class AuthLoginRequest(BaseRequest):
     def payload(self):
         return self.to_dict()
 
-    def validate(self):
-        pass
-
     @classmethod
     def from_dict(cls, d: Dict[str, str]):
         if not all(k in d for k in AUTH_LOGIN_KEYS):

--- a/pythx/models/request/auth_login.py
+++ b/pythx/models/request/auth_login.py
@@ -4,14 +4,15 @@ from typing import Any, Dict, List
 
 import dateutil.parser
 
-from pythx.models.exceptions import RequestDecodeError, RequestValidationError
+from pythx.models.exceptions import RequestValidationError
 from pythx.models.request.base import BaseRequest
-from pythx.models.util import dict_delete_none_fields
-
-AUTH_LOGIN_KEYS = ("ethAddress", "password")
+from pythx.models.util import dict_delete_none_fields, resolve_schema
 
 
 class AuthLoginRequest(BaseRequest):
+    with open(resolve_schema(__file__, "auth-login.json")) as sf:
+        schema = json.load(sf)
+
     def __init__(self, eth_address: str, password: str):
         self.eth_address = eth_address
         self.password = password
@@ -38,11 +39,10 @@ class AuthLoginRequest(BaseRequest):
 
     @classmethod
     def from_dict(cls, d: Dict[str, str]):
-        if not all(k in d for k in AUTH_LOGIN_KEYS):
-            raise RequestDecodeError(
-                "Not all required keys {} found in data {}".format(AUTH_LOGIN_KEYS, d)
-            )
+        cls.validate(d)
         return cls(eth_address=d["ethAddress"], password=d["password"])
 
     def to_dict(self):
-        return {"ethAddress": self.eth_address, "password": self.password}
+        d = {"ethAddress": self.eth_address, "password": self.password}
+        self.validate(d)
+        return d

--- a/pythx/models/request/auth_logout.py
+++ b/pythx/models/request/auth_logout.py
@@ -4,12 +4,15 @@ from typing import Any, Dict, List
 
 import dateutil.parser
 
-from pythx.models.exceptions import RequestDecodeError, RequestValidationError
+from pythx.models.exceptions import RequestValidationError
 from pythx.models.request.base import BaseRequest
-from pythx.models.util import dict_delete_none_fields
+from pythx.models.util import dict_delete_none_fields, resolve_schema
 
 
 class AuthLogoutRequest(BaseRequest):
+    with open(resolve_schema(__file__, "auth-logout.json")) as sf:
+        schema = json.load(sf)
+
     def __init__(self, global_: bool = False):
         self.global_ = global_
 
@@ -35,9 +38,10 @@ class AuthLogoutRequest(BaseRequest):
 
     @classmethod
     def from_dict(cls, d: Dict):
-        if "global" not in d:
-            raise RequestDecodeError("Required key 'global' not in data {}".format(d))
+        cls.validate(d)
         return cls(global_=d["global"])
 
     def to_dict(self):
-        return {"global": self.global_}
+        d = {"global": self.global_}
+        self.validate(d)
+        return d

--- a/pythx/models/request/auth_logout.py
+++ b/pythx/models/request/auth_logout.py
@@ -33,9 +33,6 @@ class AuthLogoutRequest(BaseRequest):
     def payload(self):
         return {}
 
-    def validate(self):
-        pass
-
     @classmethod
     def from_dict(cls, d: Dict):
         if "global" not in d:

--- a/pythx/models/request/auth_refresh.py
+++ b/pythx/models/request/auth_refresh.py
@@ -36,9 +36,6 @@ class AuthRefreshRequest(BaseRequest):
     def payload(self):
         return {"accessToken": self.access_token, "refreshToken": self.refresh_token}
 
-    def validate(self):
-        pass
-
     @classmethod
     def from_dict(cls, d: Dict):
         if not all(k in d for k in AUTH_REFRESH_KEYS):

--- a/pythx/models/request/auth_refresh.py
+++ b/pythx/models/request/auth_refresh.py
@@ -4,14 +4,15 @@ from typing import Any, Dict, List
 
 import dateutil.parser
 
-from pythx.models.exceptions import RequestDecodeError, RequestValidationError
+from pythx.models.exceptions import RequestValidationError
 from pythx.models.request.base import BaseRequest
-from pythx.models.util import dict_delete_none_fields
-
-AUTH_REFRESH_KEYS = ("access", "refresh")
+from pythx.models.util import dict_delete_none_fields, resolve_schema
 
 
 class AuthRefreshRequest(BaseRequest):
+    with open(resolve_schema(__file__, "auth-refresh.json")) as sf:
+        schema = json.load(sf)
+
     def __init__(self, access_token: str, refresh_token: str):
         self.access_token = access_token
         self.refresh_token = refresh_token
@@ -38,11 +39,10 @@ class AuthRefreshRequest(BaseRequest):
 
     @classmethod
     def from_dict(cls, d: Dict):
-        if not all(k in d for k in AUTH_REFRESH_KEYS):
-            raise RequestDecodeError(
-                "Not all required keys {} found in data {}".format(AUTH_REFRESH_KEYS, d)
-            )
+        cls.validate(d)
         return cls(access_token=d["access"], refresh_token=d["refresh"])
 
     def to_dict(self):
-        return {"access": self.access_token, "refresh": self.refresh_token}
+        d = {"access": self.access_token, "refresh": self.refresh_token}
+        self.validate(d)
+        return d

--- a/pythx/models/request/base.py
+++ b/pythx/models/request/base.py
@@ -1,6 +1,8 @@
 import abc
 import json
+
 import jsonschema
+
 from pythx.models.exceptions import RequestValidationError
 
 

--- a/pythx/models/request/base.py
+++ b/pythx/models/request/base.py
@@ -1,8 +1,19 @@
 import abc
 import json
+import jsonschema
+from pythx.models.exceptions import RequestValidationError
 
 
 class BaseRequest(abc.ABC):
+    schema = None
+
+    @classmethod
+    def validate(cls, candidate):
+        try:
+            jsonschema.validate(candidate, cls.schema)
+        except jsonschema.ValidationError as e:
+            raise RequestValidationError(e)
+
     @classmethod
     def from_json(cls, json_str: str):
         parsed = json.loads(json_str)
@@ -18,10 +29,6 @@ class BaseRequest(abc.ABC):
     @abc.abstractmethod
     def to_dict(self):
         pass
-
-    # @abc.abstractmethod
-    # def validate(self):
-    #     pass
 
     @abc.abstractproperty
     def payload(self):

--- a/pythx/models/request/base.py
+++ b/pythx/models/request/base.py
@@ -19,9 +19,9 @@ class BaseRequest(abc.ABC):
     def to_dict(self):
         pass
 
-    @abc.abstractmethod
-    def validate(self):
-        pass
+    # @abc.abstractmethod
+    # def validate(self):
+    #     pass
 
     @abc.abstractproperty
     def payload(self):

--- a/pythx/models/request/base.py
+++ b/pythx/models/request/base.py
@@ -1,9 +1,13 @@
 import abc
 import json
+import logging
 
 import jsonschema
 
 from pythx.models.exceptions import RequestValidationError
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class BaseRequest(abc.ABC):
@@ -12,7 +16,8 @@ class BaseRequest(abc.ABC):
     @classmethod
     def validate(cls, candidate):
         if cls.schema is None:
-            raise TypeError("Cannot use BaseRequest.validate without a schema")
+            LOGGER.warning("Cannot validate {} without a schema".format(cls.__name__))
+            return
         try:
             jsonschema.validate(candidate, cls.schema)
         except jsonschema.ValidationError as e:

--- a/pythx/models/request/base.py
+++ b/pythx/models/request/base.py
@@ -11,6 +11,8 @@ class BaseRequest(abc.ABC):
 
     @classmethod
     def validate(cls, candidate):
+        if cls.schema is None:
+            raise TypeError("Cannot use BaseRequest.validate without a schema")
         try:
             jsonschema.validate(candidate, cls.schema)
         except jsonschema.ValidationError as e:

--- a/pythx/models/request/detected_issues.py
+++ b/pythx/models/request/detected_issues.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 
 import dateutil.parser
 
-from pythx.models.exceptions import RequestDecodeError, RequestValidationError
+from pythx.models.exceptions import RequestValidationError
 from pythx.models.request.analysis_status import AnalysisStatusRequest
 from pythx.models.util import dict_delete_none_fields
 

--- a/pythx/models/request/oas.py
+++ b/pythx/models/request/oas.py
@@ -36,9 +36,6 @@ class OASRequest(BaseRequest):
     def headers(self):
         return {}
 
-    def validate(self):
-        pass
-
     @classmethod
     def from_dict(cls, d):
         return cls()

--- a/pythx/models/request/oas.py
+++ b/pythx/models/request/oas.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 
 import dateutil.parser
 
-from pythx.models.exceptions import RequestDecodeError, RequestValidationError
+from pythx.models.exceptions import RequestValidationError
 from pythx.models.request.analysis_status import AnalysisStatusRequest
 from pythx.models.request.base import BaseRequest
 from pythx.models.util import dict_delete_none_fields
@@ -13,7 +13,7 @@ from pythx.models.util import dict_delete_none_fields
 class OASRequest(BaseRequest):
     def __init__(self, mode="yaml"):
         if not mode in ("yaml", "html"):
-            raise RequestDecodeError("'mode' must be one of {html,yaml}")
+            raise RequestValidationError("'mode' must be one of {html,yaml}")
         self.mode = mode
 
     @property

--- a/pythx/models/request/schema/analysis-submission.json
+++ b/pythx/models/request/schema/analysis-submission.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "anyOf": [{
+            "required": ["bytecode", "analysisMode"]
+        },
+        {
+            "required": ["sources", "analysisMode"]
+        },
+        {
+            "required": ["sources", "bytecode", "analysisMode"]
+        }
+    ],
+    "properties": {
+        "contractName": {
+            "type": "string"
+        },
+        "bytecode": {
+            "type": "string"
+        },
+        "deployedBytecode": {
+            "type": "string"
+        },
+        "sourceMap": {
+            "type": "string"
+        },
+        "deployedSourceMap": {
+            "type": "string"
+        },
+        "sources": {
+            "type": "object",
+            "patternProperties": {
+                ".*.sol$": {
+                    "type": "object",
+                    "anyOf": [{
+                            "required": ["source"]
+                        },
+                        {
+                            "required": ["ast"]
+                        }
+                    ],
+                    "properties": {
+                        "source": {
+                            "type": "string"
+                        },
+                        "ast": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "sourceList": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "version": {
+            "type": "string"
+        },
+        "analysisMode": {
+            "enum": ["quick", "full"]
+        }
+    }
+}

--- a/pythx/models/request/schema/auth-login.json
+++ b/pythx/models/request/schema/auth-login.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": [
+      "ethAddress",
+      "password"
+    ],
+    "properties": {
+      "ethAddress": {"type": "string"},
+      "password": {"type": "string"}
+    }
+  }

--- a/pythx/models/request/schema/auth-logout.json
+++ b/pythx/models/request/schema/auth-logout.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": ["global"],
+    "properties": {
+        "global": {
+            "type": "boolean"
+        }
+    }
+}

--- a/pythx/models/request/schema/auth-refresh.json
+++ b/pythx/models/request/schema/auth-refresh.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": [
+        "access",
+        "refresh"
+    ],
+    "properties": {
+        "access": {
+            "type": "string"
+        },
+        "refresh": {
+            "type": "string"
+        }
+    }
+}

--- a/pythx/models/request/version.py
+++ b/pythx/models/request/version.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 
 import dateutil.parser
 
-from pythx.models.exceptions import RequestDecodeError, RequestValidationError
+from pythx.models.exceptions import RequestValidationError
 from pythx.models.request.analysis_status import AnalysisStatusRequest
 from pythx.models.request.base import BaseRequest
 from pythx.models.util import dict_delete_none_fields

--- a/pythx/models/request/version.py
+++ b/pythx/models/request/version.py
@@ -31,9 +31,6 @@ class VersionRequest(BaseRequest):
     def headers(self):
         return {}
 
-    def validate(self):
-        pass
-
     @classmethod
     def from_dict(cls, d):
         return cls()

--- a/pythx/models/response/analysis.py
+++ b/pythx/models/response/analysis.py
@@ -4,7 +4,6 @@ from enum import Enum
 import dateutil.parser
 from inflection import underscore
 
-from pythx.models.exceptions import ResponseDecodeError
 from pythx.models.response.base import BaseResponse
 from pythx.models.util import deserialize_api_timestamp, serialize_api_timestamp
 

--- a/pythx/models/response/analysis.py
+++ b/pythx/models/response/analysis.py
@@ -69,20 +69,22 @@ class Analysis(BaseResponse):
         return d
 
     def __eq__(self, candidate):
-        return all((
-            self.uuid == candidate.uuid,
-            self.api_version == candidate.api_version,
-            self.mythril_version == candidate.mythril_version,
-            self.maestro_version == candidate.maestro_version,
-            self.harvey_version == candidate.harvey_version,
-            self.maru_version == candidate.maru_version,
-            self.queue_time == candidate.queue_time,
-            self.run_time == candidate.run_time,
-            self.status == candidate.status,
-            self.submitted_at == candidate.submitted_at,
-            self.submitted_by == candidate.submitted_by,
-            self.error == candidate.error
-        ))
+        return all(
+            (
+                self.uuid == candidate.uuid,
+                self.api_version == candidate.api_version,
+                self.mythril_version == candidate.mythril_version,
+                self.maestro_version == candidate.maestro_version,
+                self.harvey_version == candidate.harvey_version,
+                self.maru_version == candidate.maru_version,
+                self.queue_time == candidate.queue_time,
+                self.run_time == candidate.run_time,
+                self.status == candidate.status,
+                self.submitted_at == candidate.submitted_at,
+                self.submitted_by == candidate.submitted_by,
+                self.error == candidate.error,
+            )
+        )
 
     def __repr__(self):
         return "<Analysis uuid={} status={}>".format(self.uuid, self.status)

--- a/pythx/models/response/analysis.py
+++ b/pythx/models/response/analysis.py
@@ -88,3 +88,22 @@ class Analysis(BaseResponse):
             d.update({"error": self.error})
 
         return d
+
+    def __eq__(self, candidate):
+        return all((
+            self.uuid == candidate.uuid,
+            self.api_version == candidate.api_version,
+            self.mythril_version == candidate.mythril_version,
+            self.maestro_version == candidate.maestro_version,
+            self.harvey_version == candidate.harvey_version,
+            self.maru_version == candidate.maru_version,
+            self.queue_time == candidate.queue_time,
+            self.run_time == candidate.run_time,
+            self.status == candidate.status,
+            self.submitted_at == candidate.submitted_at,
+            self.submitted_by == candidate.submitted_by,
+            self.error == candidate.error
+        ))
+
+    def __repr__(self):
+        return "<Analysis uuid={} status={}>".format(self.uuid, self.status)

--- a/pythx/models/response/analysis.py
+++ b/pythx/models/response/analysis.py
@@ -8,19 +8,6 @@ from pythx.models.exceptions import ResponseDecodeError
 from pythx.models.response.base import BaseResponse
 from pythx.models.util import deserialize_api_timestamp, serialize_api_timestamp
 
-ANALYSIS_KEYS = (
-    "uuid",
-    "apiVersion",
-    "mythrilVersion",
-    "maestroVersion",
-    "harveyVersion",
-    "maruVersion",
-    "queueTime",
-    "status",
-    "submittedBy",
-    "submittedAt",
-)
-
 
 class AnalysisStatus(str, Enum):
     QUEUED = "Queued"
@@ -58,17 +45,10 @@ class Analysis(BaseResponse):
         self.submitted_by = submitted_by
         self.error = error
 
-    def validate(self):
-        pass
-
     @classmethod
     def from_dict(cls, d):
-        if all(k in d for k in ANALYSIS_KEYS):
-            d = {underscore(k): v for k, v in d.items()}
-            return cls(**d)
-        raise ResponseDecodeError(
-            "Not all required keys {} found in data {}".format(ANALYSIS_KEYS, d)
-        )
+        d = {underscore(k): v for k, v in d.items()}
+        return cls(**d)
 
     def to_dict(self):
         d = {

--- a/pythx/models/response/analysis_list.py
+++ b/pythx/models/response/analysis_list.py
@@ -5,39 +5,39 @@ from pythx.models.exceptions import ResponseDecodeError, ResponseValidationError
 from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
 from pythx.models.response.issue import Issue, SourceFormat, SourceType
+from pythx.models.util import resolve_schema
 
-ANALYSIS_LIST_KEYS = ["analyses", "total"]
+
 INDEX_ERROR_MSG = "Analysis at index {} was not fetched"
 
 
 class AnalysisListResponse(BaseResponse):
+    with open(resolve_schema(__file__, "analysis-list.json")) as sf:
+            schema = json.load(sf)
+
     def __init__(self, analyses: List[Analysis], total: int) -> None:
         self.analyses = analyses
         self.total = total
 
-    def validate(self) -> bool:
-        if self.total < 0:
-            raise ResponseValidationError(
-                "Encountered invalid total value: {}".format(self.total)
-            )
-        # TODO: Add validation method to Analysis and call recursively
+    @classmethod
+    def validate(cls, candidate):
+        super().validate(candidate)
+        if not type(candidate) == dict:
+            raise ResponseValidationError("Expected type dict but got {}".format(type(candidate)))
 
     @classmethod
     def from_dict(cls, d: dict):
-        if not all(k in d for k in ANALYSIS_LIST_KEYS):
-            raise ResponseDecodeError(
-                "Not all required keys {} found in data {}".format(
-                    ANALYSIS_LIST_KEYS, d
-                )
-            )
+        cls.validate(d)
         analyses = [Analysis.from_dict(a) for a in d["analyses"]]
         return cls(analyses=analyses, total=d["total"])
 
     def to_dict(self):
-        return {
+        d = {
             "analyses": [a.to_dict() for a in self.analyses],
             "total": len(self.analyses),
         }
+        self.validate(d)
+        return d
 
     def __iter__(self):
         for analysis in self.analyses:

--- a/pythx/models/response/analysis_list.py
+++ b/pythx/models/response/analysis_list.py
@@ -7,13 +7,12 @@ from pythx.models.response.base import BaseResponse
 from pythx.models.response.issue import Issue, SourceFormat, SourceType
 from pythx.models.util import resolve_schema
 
-
 INDEX_ERROR_MSG = "Analysis at index {} was not fetched"
 
 
 class AnalysisListResponse(BaseResponse):
     with open(resolve_schema(__file__, "analysis-list.json")) as sf:
-            schema = json.load(sf)
+        schema = json.load(sf)
 
     def __init__(self, analyses: List[Analysis], total: int) -> None:
         self.analyses = analyses
@@ -23,7 +22,9 @@ class AnalysisListResponse(BaseResponse):
     def validate(cls, candidate):
         super().validate(candidate)
         if not type(candidate) == dict:
-            raise ResponseValidationError("Expected type dict but got {}".format(type(candidate)))
+            raise ResponseValidationError(
+                "Expected type dict but got {}".format(type(candidate))
+            )
 
     @classmethod
     def from_dict(cls, d: dict):
@@ -70,7 +71,9 @@ class AnalysisListResponse(BaseResponse):
 
     def __contains__(self, item):
         if not type(item) in (Analysis, str):
-            raise ValueError("Expected type Analysis or str but got {}".format(type(item)))
+            raise ValueError(
+                "Expected type Analysis or str but got {}".format(type(item))
+            )
         uuid = item.uuid if type(item) == Analysis else item
         return uuid in map(lambda x: x.uuid, self.analyses)
 

--- a/pythx/models/response/analysis_list.py
+++ b/pythx/models/response/analysis_list.py
@@ -7,6 +7,7 @@ from pythx.models.response.base import BaseResponse
 from pythx.models.response.issue import Issue, SourceFormat, SourceType
 
 ANALYSIS_LIST_KEYS = ["analyses", "total"]
+INDEX_ERROR_MSG = "Analysis at index {} was not fetched"
 
 
 class AnalysisListResponse(BaseResponse):
@@ -37,3 +38,41 @@ class AnalysisListResponse(BaseResponse):
             "analyses": [a.to_dict() for a in self.analyses],
             "total": len(self.analyses),
         }
+
+    def __iter__(self):
+        for analysis in self.analyses:
+            yield analysis
+
+    def __getitem__(self, idx):
+        try:
+            return self.analyses[idx]
+        except IndexError:
+            raise IndexError(INDEX_ERROR_MSG.format(idx))
+
+    def __setitem__(self, idx, value):
+        try:
+            self.analyses[idx] = value
+        except IndexError:
+            raise IndexError(INDEX_ERROR_MSG.format(idx))
+
+    def __delitem__(self, idx):
+        try:
+            del self.analyses[idx]
+            self.total -= 1
+        except IndexError:
+            raise IndexError(INDEX_ERROR_MSG.format(idx))
+
+    def __len__(self):
+        return self.total
+
+    def __reversed__(self):
+        return reversed(self.analyses)
+
+    def __contains__(self, item):
+        if not type(item) in (Analysis, str):
+            raise ValueError("Expected type Analysis or str but got {}".format(type(item)))
+        uuid = item.uuid if type(item) == Analysis else item
+        return uuid in map(lambda x: x.uuid, self.analyses)
+
+    def __eq__(self, candidate):
+        return self.total == candidate.total and self.analyses == candidate.analyses

--- a/pythx/models/response/analysis_list.py
+++ b/pythx/models/response/analysis_list.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Dict, List
 
-from pythx.models.exceptions import ResponseDecodeError, ResponseValidationError
+from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
 from pythx.models.response.issue import Issue, SourceFormat, SourceType

--- a/pythx/models/response/analysis_submission.py
+++ b/pythx/models/response/analysis_submission.py
@@ -5,22 +5,25 @@ from pythx.models.exceptions import ResponseDecodeError
 from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
 from pythx.models.response.issue import Issue, SourceFormat, SourceType
+from pythx.models.util import resolve_schema
 
 
 class AnalysisSubmissionResponse(BaseResponse):
+    with open(resolve_schema(__file__, "analysis-submission.json")) as sf:
+            schema = json.load(sf)
+
     def __init__(self, analysis: Analysis):
         self.analysis = analysis
 
-    def validate(self) -> bool:
-        # return self.analysis.validate()
-        pass
-
     @classmethod
     def from_dict(cls, d):
+        cls.validate(d)
         return cls(analysis=Analysis.from_dict(d))
 
     def to_dict(self):
-        return self.analysis.to_dict()
+        d = self.analysis.to_dict()
+        self.validate(d)
+        return d
 
     def __getattr__(self, name):
         return getattr(self.analysis, name)

--- a/pythx/models/response/analysis_submission.py
+++ b/pythx/models/response/analysis_submission.py
@@ -9,7 +9,7 @@ from pythx.models.util import resolve_schema
 
 class AnalysisSubmissionResponse(BaseResponse):
     with open(resolve_schema(__file__, "analysis-submission.json")) as sf:
-            schema = json.load(sf)
+        schema = json.load(sf)
 
     def __init__(self, analysis: Analysis):
         self.analysis = analysis

--- a/pythx/models/response/analysis_submission.py
+++ b/pythx/models/response/analysis_submission.py
@@ -1,7 +1,6 @@
 import json
 from typing import Any, Dict, List
 
-from pythx.models.exceptions import ResponseDecodeError
 from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
 from pythx.models.response.issue import Issue, SourceFormat, SourceType

--- a/pythx/models/response/analysis_submission.py
+++ b/pythx/models/response/analysis_submission.py
@@ -21,3 +21,6 @@ class AnalysisSubmissionResponse(BaseResponse):
 
     def to_dict(self):
         return self.analysis.to_dict()
+
+    def __getattr__(self, name):
+        return getattr(self.analysis, name)

--- a/pythx/models/response/auth_login.py
+++ b/pythx/models/response/auth_login.py
@@ -6,9 +6,10 @@ from pythx.models.response.base import BaseResponse
 from pythx.models.response.issue import Issue, SourceFormat, SourceType
 from pythx.models.util import resolve_schema
 
+
 class AuthLoginResponse(BaseResponse):
     with open(resolve_schema(__file__, "auth-login.json")) as sf:
-            schema = json.load(sf)
+        schema = json.load(sf)
 
     def __init__(self, access_token: str, refresh_token: str):
         self.access_token = access_token

--- a/pythx/models/response/auth_login.py
+++ b/pythx/models/response/auth_login.py
@@ -1,7 +1,6 @@
 import json
 from typing import Any, Dict, List
 
-from pythx.models.exceptions import ResponseDecodeError
 from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
 from pythx.models.response.issue import Issue, SourceFormat, SourceType

--- a/pythx/models/response/auth_login.py
+++ b/pythx/models/response/auth_login.py
@@ -5,25 +5,22 @@ from pythx.models.exceptions import ResponseDecodeError
 from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
 from pythx.models.response.issue import Issue, SourceFormat, SourceType
-
-AUTH_LOGIN_KEYS = ("access", "refresh")
-
+from pythx.models.util import resolve_schema
 
 class AuthLoginResponse(BaseResponse):
+    with open(resolve_schema(__file__, "auth-login.json")) as sf:
+            schema = json.load(sf)
+
     def __init__(self, access_token: str, refresh_token: str):
         self.access_token = access_token
         self.refresh_token = refresh_token
 
-    def validate(self):
-        pass
-
     @classmethod
     def from_dict(cls, d: Dict):
-        if not all(k in d for k in AUTH_LOGIN_KEYS):
-            raise ResponseDecodeError(
-                "Not all required keys {} found in data {}".format(AUTH_LOGIN_KEYS, d)
-            )
+        cls.validate(d)
         return cls(access_token=d["access"], refresh_token=d["refresh"])
 
     def to_dict(self):
-        return {"access": self.access_token, "refresh": self.refresh_token}
+        d = {"access": self.access_token, "refresh": self.refresh_token}
+        self.validate(d)
+        return d

--- a/pythx/models/response/auth_logout.py
+++ b/pythx/models/response/auth_logout.py
@@ -1,23 +1,22 @@
 import json
 from typing import Any, Dict, List
 
-from pythx.models.exceptions import ResponseDecodeError
+from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
 from pythx.models.response.issue import Issue, SourceFormat, SourceType
+from pythx.models.util import resolve_schema
 
 
 class AuthLogoutResponse(BaseResponse):
-    def validate(self):
-        pass
-
     @classmethod
     def from_dict(cls, d: Dict):
         if not d == {}:
-            raise ResponseDecodeError(
+            raise ResponseValidationError(
                 "The logout response should be empty but got data: {}".format(d)
             )
         return cls()
 
     def to_dict(self):
-        return {}
+        d = {}
+        return d

--- a/pythx/models/response/auth_refresh.py
+++ b/pythx/models/response/auth_refresh.py
@@ -6,9 +6,10 @@ from pythx.models.response.base import BaseResponse
 from pythx.models.response.issue import Issue, SourceFormat, SourceType
 from pythx.models.util import resolve_schema
 
+
 class AuthRefreshResponse(BaseResponse):
     with open(resolve_schema(__file__, "auth-refresh.json")) as sf:
-            schema = json.load(sf)
+        schema = json.load(sf)
 
     def __init__(self, access_token: str, refresh_token: str):
         self.access_token = access_token

--- a/pythx/models/response/auth_refresh.py
+++ b/pythx/models/response/auth_refresh.py
@@ -5,25 +5,22 @@ from pythx.models.exceptions import ResponseDecodeError
 from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
 from pythx.models.response.issue import Issue, SourceFormat, SourceType
-
-AUTH_LOGIN_KEYS = ("access", "refresh")
-
+from pythx.models.util import resolve_schema
 
 class AuthRefreshResponse(BaseResponse):
+    with open(resolve_schema(__file__, "auth-refresh.json")) as sf:
+            schema = json.load(sf)
+
     def __init__(self, access_token: str, refresh_token: str):
         self.access_token = access_token
         self.refresh_token = refresh_token
 
-    def validate(self):
-        pass
-
     @classmethod
     def from_dict(cls, d: Dict):
-        if not all(k in d for k in AUTH_LOGIN_KEYS):
-            raise ResponseDecodeError(
-                "Not all required keys {} found in data {}".format(AUTH_LOGIN_KEYS, d)
-            )
+        cls.validate(d)
         return cls(access_token=d["access"], refresh_token=d["refresh"])
 
     def to_dict(self):
-        return {"access": self.access_token, "refresh": self.refresh_token}
+        d = {"access": self.access_token, "refresh": self.refresh_token}
+        self.validate(d)
+        return d

--- a/pythx/models/response/auth_refresh.py
+++ b/pythx/models/response/auth_refresh.py
@@ -1,7 +1,6 @@
 import json
 from typing import Any, Dict, List
 
-from pythx.models.exceptions import ResponseDecodeError
 from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
 from pythx.models.response.issue import Issue, SourceFormat, SourceType

--- a/pythx/models/response/base.py
+++ b/pythx/models/response/base.py
@@ -1,6 +1,8 @@
 import abc
 import json
+
 import jsonschema
+
 from pythx.models.exceptions import ResponseValidationError
 
 
@@ -29,4 +31,3 @@ class BaseResponse(abc.ABC):
     @abc.abstractmethod
     def to_dict(self):
         pass
-

--- a/pythx/models/response/base.py
+++ b/pythx/models/response/base.py
@@ -1,9 +1,13 @@
 import abc
 import json
+import logging
 
 import jsonschema
 
 from pythx.models.exceptions import ResponseValidationError
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class BaseResponse(abc.ABC):
@@ -12,7 +16,8 @@ class BaseResponse(abc.ABC):
     @classmethod
     def validate(cls, candidate):
         if cls.schema is None:
-            raise TypeError("Cannot use BaseResponse.validate without a schema")
+            LOGGER.warning("Cannot validate {} without a schema".format(cls.__name__))
+            return
         try:
             jsonschema.validate(candidate, cls.schema)
         except jsonschema.ValidationError as e:

--- a/pythx/models/response/base.py
+++ b/pythx/models/response/base.py
@@ -11,6 +11,8 @@ class BaseResponse(abc.ABC):
 
     @classmethod
     def validate(cls, candidate):
+        if cls.schema is None:
+            raise TypeError("Cannot use BaseResponse.validate without a schema")
         try:
             jsonschema.validate(candidate, cls.schema)
         except jsonschema.ValidationError as e:

--- a/pythx/models/response/base.py
+++ b/pythx/models/response/base.py
@@ -1,8 +1,19 @@
 import abc
 import json
+import jsonschema
+from pythx.models.exceptions import ResponseValidationError
 
 
 class BaseResponse(abc.ABC):
+    schema = None
+
+    @classmethod
+    def validate(cls, candidate):
+        try:
+            jsonschema.validate(candidate, cls.schema)
+        except jsonschema.ValidationError as e:
+            raise ResponseValidationError(e)
+
     @classmethod
     def from_json(cls, json_str: str):
         parsed = json.loads(json_str)
@@ -19,6 +30,3 @@ class BaseResponse(abc.ABC):
     def to_dict(self):
         pass
 
-    @abc.abstractmethod
-    def validate(self):
-        pass

--- a/pythx/models/response/detected_issues.py
+++ b/pythx/models/response/detected_issues.py
@@ -66,3 +66,7 @@ class DetectedIssuesResponse(BaseResponse):
 
     def __len__(self):
         return len(self.issues)
+
+    def __iter__(self):
+        for issue in self.issues:
+            yield issue

--- a/pythx/models/response/detected_issues.py
+++ b/pythx/models/response/detected_issues.py
@@ -58,3 +58,8 @@ class DetectedIssuesResponse(BaseResponse):
                 "meta": self.meta_data,
             }
         ]
+
+    def __contains__(self, key: str):
+        if not type(key) == str:
+            raise ValueError("Expected SWC ID of type str but got {} of type {}".format(key, type(key)))
+        return any(map(lambda i: i.swc_id == key, self.issues))

--- a/pythx/models/response/detected_issues.py
+++ b/pythx/models/response/detected_issues.py
@@ -70,3 +70,12 @@ class DetectedIssuesResponse(BaseResponse):
     def __iter__(self):
         for issue in self.issues:
             yield issue
+
+    def __getitem__(self, key):
+        return self.issues[key]
+
+    def __setitem__(self, key, value):
+        self.issues[key] = value
+
+    def __delitem__(self, key):
+        del self.issues[key]

--- a/pythx/models/response/detected_issues.py
+++ b/pythx/models/response/detected_issues.py
@@ -5,11 +5,13 @@ from pythx.models.exceptions import ResponseDecodeError
 from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
 from pythx.models.response.issue import Issue, SourceFormat, SourceType
-
-DETECTED_ISSUES_KEYS = ("issues", "sourceType", "sourceFormat", "sourceList", "meta")
+from pythx.models.util import resolve_schema
 
 
 class DetectedIssuesResponse(BaseResponse):
+    with open(resolve_schema(__file__, "detected-issues.json")) as sf:
+            schema = json.load(sf)
+
     def __init__(
         self,
         issues: List[Issue],
@@ -24,21 +26,9 @@ class DetectedIssuesResponse(BaseResponse):
         self.source_list = source_list
         self.meta_data = meta_data
 
-    def validate(self) -> bool:
-        pass
-
     @classmethod
     def from_dict(cls, d):
-        if (
-            type(d) != list
-            or len(d) != 1
-            or not all(k in d[0] for k in DETECTED_ISSUES_KEYS)
-        ):
-            raise ResponseDecodeError(
-                "Not all required keys {} found in data {}".format(
-                    DETECTED_ISSUES_KEYS, d
-                )
-            )
+        cls.validate(d)
         d = d[0]
         return cls(
             issues=[Issue.from_dict(i) for i in d["issues"]],
@@ -49,7 +39,7 @@ class DetectedIssuesResponse(BaseResponse):
         )
 
     def to_dict(self):
-        return [
+        d = [
             {
                 "issues": [i.to_dict() for i in self.issues],
                 "sourceType": self.source_type,
@@ -58,6 +48,8 @@ class DetectedIssuesResponse(BaseResponse):
                 "meta": self.meta_data,
             }
         ]
+        self.validate(d)
+        return d
 
     def __contains__(self, key: str):
         if not type(key) == str:

--- a/pythx/models/response/detected_issues.py
+++ b/pythx/models/response/detected_issues.py
@@ -1,7 +1,6 @@
 import json
 from typing import Any, Dict, List
 
-from pythx.models.exceptions import ResponseDecodeError
 from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
 from pythx.models.response.issue import Issue, SourceFormat, SourceType

--- a/pythx/models/response/detected_issues.py
+++ b/pythx/models/response/detected_issues.py
@@ -9,7 +9,7 @@ from pythx.models.util import resolve_schema
 
 class DetectedIssuesResponse(BaseResponse):
     with open(resolve_schema(__file__, "detected-issues.json")) as sf:
-            schema = json.load(sf)
+        schema = json.load(sf)
 
     def __init__(
         self,
@@ -52,7 +52,11 @@ class DetectedIssuesResponse(BaseResponse):
 
     def __contains__(self, key: str):
         if not type(key) == str:
-            raise ValueError("Expected SWC ID of type str but got {} of type {}".format(key, type(key)))
+            raise ValueError(
+                "Expected SWC ID of type str but got {} of type {}".format(
+                    key, type(key)
+                )
+            )
         return any(map(lambda i: i.swc_id == key, self.issues))
 
     def __len__(self):

--- a/pythx/models/response/detected_issues.py
+++ b/pythx/models/response/detected_issues.py
@@ -63,3 +63,6 @@ class DetectedIssuesResponse(BaseResponse):
         if not type(key) == str:
             raise ValueError("Expected SWC ID of type str but got {} of type {}".format(key, type(key)))
         return any(map(lambda i: i.swc_id == key, self.issues))
+
+    def __len__(self):
+        return len(self.issues)

--- a/pythx/models/response/issue.py
+++ b/pythx/models/response/issue.py
@@ -6,8 +6,6 @@ from inflection import underscore
 
 from pythx.models.exceptions import ResponseDecodeError
 
-SOURCE_LOCATION_KEYS = ("sourceMap", "sourceType", "sourceFormat", "sourceList")
-
 
 class Severity(str, Enum):
     NONE = "None"
@@ -44,18 +42,8 @@ class SourceLocation:
         self.source_format = source_format
         self.source_list = source_list
 
-    def validate(self):
-        pass
-
     @classmethod
     def from_dict(cls, d):
-        if not all(k in d for k in SOURCE_LOCATION_KEYS):
-            raise ResponseDecodeError(
-                "Not all required keys {} found in data {}".format(
-                    SOURCE_LOCATION_KEYS, d
-                )
-            )
-
         return cls(
             source_map=d["sourceMap"],
             source_type=SourceType(d["sourceType"]),
@@ -98,7 +86,6 @@ class Issue:
 
     @classmethod
     def from_dict(cls, d):
-        # TODO: validate
         locs = [
             SourceLocation(
                 source_map=loc.get("sourceMap"),

--- a/pythx/models/response/issue.py
+++ b/pythx/models/response/issue.py
@@ -4,8 +4,6 @@ from typing import Any, Dict, List, Tuple
 
 from inflection import underscore
 
-from pythx.models.exceptions import ResponseDecodeError
-
 
 class Severity(str, Enum):
     NONE = "None"

--- a/pythx/models/response/oas.py
+++ b/pythx/models/response/oas.py
@@ -5,21 +5,21 @@ from pythx.models.exceptions import ResponseDecodeError
 from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
 from pythx.models.response.issue import Issue, SourceFormat, SourceType
+from pythx.models.util import resolve_schema
 
 
 class OASResponse(BaseResponse):
+    with open(resolve_schema(__file__, "openapi.json")) as sf:
+            schema = json.load(sf)
+
     def __init__(self, data: str):
         if not type(data) == str:
             raise TypeError("Expected data type str but got {}".format(type(data)))
         self.data = data
 
-    def validate(self):
-        pass
-
     @classmethod
     def from_dict(cls, d: Dict):
-        if not "data" in d:
-            raise ResponseDecodeError("Expected 'data' field but got {}".format(d))
+        cls.validate(d)
         return cls(data=d["data"])
 
     @classmethod
@@ -29,4 +29,5 @@ class OASResponse(BaseResponse):
         return cls.from_dict({"data": json_str})
 
     def to_dict(self):
-        return {"data": self.data}
+        d = {"data": self.data}
+        return d

--- a/pythx/models/response/oas.py
+++ b/pythx/models/response/oas.py
@@ -1,7 +1,6 @@
 import json
 from typing import Any, Dict, List
 
-from pythx.models.exceptions import ResponseDecodeError
 from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
 from pythx.models.response.issue import Issue, SourceFormat, SourceType

--- a/pythx/models/response/oas.py
+++ b/pythx/models/response/oas.py
@@ -9,7 +9,7 @@ from pythx.models.util import resolve_schema
 
 class OASResponse(BaseResponse):
     with open(resolve_schema(__file__, "openapi.json")) as sf:
-            schema = json.load(sf)
+        schema = json.load(sf)
 
     def __init__(self, data: str):
         if not type(data) == str:

--- a/pythx/models/response/schema/analysis-list.json
+++ b/pythx/models/response/schema/analysis-list.json
@@ -1,0 +1,66 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "required": [
+        "total",
+        "analyses"
+    ],
+    "properties": {
+        "total": {
+            "type": "integer"
+        },
+        "analyses": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "apiVersion",
+                    "harveyVersion",
+                    "maestroVersion",
+                    "maruVersion",
+                    "mythrilVersion",
+                    "queueTime",
+                    "runTime",
+                    "status",
+                    "submittedAt",
+                    "submittedBy",
+                    "uuid"
+                ],
+                "properties": {
+                    "apiVersion": {
+                        "type": "string"
+                    },
+                    "harveyVersion": {
+                        "type": "string"
+                    },
+                    "maestroVersion": {
+                        "type": "string"
+                    },
+                    "maruVersion": {
+                        "type": "string"
+                    },
+                    "mythrilVersion": {
+                        "type": "string"
+                    },
+                    "queueTime": {
+                        "type": "integer"
+                    },
+                    "runTime": {
+                        "type": "integer"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "submittedAt": {
+                        "type": "string"
+                    },
+                    "submittedBy": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pythx/models/response/schema/analysis-submission.json
+++ b/pythx/models/response/schema/analysis-submission.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "required": [
+        "apiVersion",
+        "harveyVersion",
+        "maestroVersion",
+        "maruVersion",
+        "mythrilVersion",
+        "queueTime",
+        "status",
+        "submittedAt",
+        "submittedBy",
+        "uuid"
+    ],
+    "properties": {
+        "apiVersion": {
+            "type": "string"
+        },
+        "harveyVersion": {
+            "type": "string"
+        },
+        "maestroVersion": {
+            "type": "string"
+        },
+        "maruVersion": {
+            "type": "string"
+        },
+        "mythrilVersion": {
+            "type": "string"
+        },
+        "queueTime": {
+            "type": "integer"
+        },
+        "status": {
+            "type": "string"
+        },
+        "submittedAt": {
+            "type": "string"
+        },
+        "submittedBy": {
+            "type": "string"
+        },
+        "uuid": {
+            "type": "string"
+        }
+    }
+}

--- a/pythx/models/response/schema/auth-login.json
+++ b/pythx/models/response/schema/auth-login.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": [
+      "access",
+      "refresh"
+    ],
+    "properties": {
+      "access": {
+        "type": "string"
+      },
+      "refresh": {
+        "type": "string"
+      }
+    }
+  }

--- a/pythx/models/response/schema/auth-refresh.json
+++ b/pythx/models/response/schema/auth-refresh.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": [
+      "access",
+      "refresh"
+    ],
+    "properties": {
+      "access": {
+        "type": "string"
+      },
+      "refresh": {
+        "type": "string"
+      }
+    }
+  }

--- a/pythx/models/response/schema/detected-issues.json
+++ b/pythx/models/response/schema/detected-issues.json
@@ -1,0 +1,105 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "array",
+    "minItems": 1,
+    "items": {
+        "type": "object",
+        "required": [
+            "issues",
+            "sourceType",
+            "sourceFormat",
+            "sourceList",
+            "meta"
+        ],
+        "properties": {
+            "issues": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": [
+                        "swcID",
+                        "swcTitle",
+                        "description",
+                        "severity",
+                        "locations",
+                        "extra"
+                    ],
+                    "properties": {
+                        "swcID": {
+                            "type": "string",
+                            "default": ""
+                        },
+                        "swcTitle": {
+                            "type": "string"
+                        },
+                        "description": {
+                            "type": "object",
+                            "required": [
+                                "head",
+                                "tail"
+                            ],
+                            "properties": {
+                                "head": {
+                                    "type": "string"
+                                },
+                                "tail": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "severity": {
+                            "type": "string"
+                        },
+                        "locations": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "sourceMap",
+                                    "sourceType",
+                                    "sourceFormat",
+                                    "sourceList"
+                                ],
+                                "properties": {
+                                    "sourceMap": {
+                                        "type": "string"
+                                    },
+                                    "sourceType": {
+                                        "type": "string"
+                                    },
+                                    "sourceFormat": {
+                                        "type": "string"
+                                    },
+                                    "sourceList": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "extra": {
+                            "type": "object"
+                        }
+                    }
+                }
+            },
+            "sourceType": {
+                "type": "string"
+            },
+            "sourceFormat": {
+                "type": "string"
+            },
+            "sourceList": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "meta": {
+                "type": "object"
+            }
+        }
+    }
+}

--- a/pythx/models/response/schema/detected-issues.json
+++ b/pythx/models/response/schema/detected-issues.json
@@ -55,10 +55,7 @@
                             "items": {
                                 "type": "object",
                                 "required": [
-                                    "sourceMap",
-                                    "sourceType",
-                                    "sourceFormat",
-                                    "sourceList"
+                                    "sourceMap"
                                 ],
                                 "properties": {
                                     "sourceMap": {

--- a/pythx/models/response/schema/openapi.json
+++ b/pythx/models/response/schema/openapi.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": ["data"],
+    "properties": {
+        "data": {
+            "type": "string"
+        }
+    }
+}

--- a/pythx/models/response/schema/version.json
+++ b/pythx/models/response/schema/version.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": [
+        "api",
+        "hash",
+        "harvey",
+        "maestro",
+        "maru",
+        "mythril"
+    ],
+    "properties": {
+        "api": {
+            "type": "string"
+        },
+        "hash": {
+            "type": "string"
+        },
+        "harvey": {
+            "type": "string"
+        },
+        "maestro": {
+            "type": "string"
+        },
+        "maru": {
+            "type": "string"
+        },
+        "mythril": {
+            "type": "string"
+        }
+    }
+}

--- a/pythx/models/response/version.py
+++ b/pythx/models/response/version.py
@@ -3,7 +3,7 @@ import json
 from typing import Any, Dict, List
 import jsonschema
 
-from pythx.models.exceptions import ResponseDecodeError, ResponseValidationError
+from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
 from pythx.models.response.issue import Issue, SourceFormat, SourceType

--- a/pythx/models/response/version.py
+++ b/pythx/models/response/version.py
@@ -1,6 +1,7 @@
-from os import path
 import json
+from os import path
 from typing import Any, Dict, List
+
 import jsonschema
 
 from pythx.models.exceptions import ResponseValidationError
@@ -12,7 +13,7 @@ from pythx.models.util import resolve_schema
 
 class VersionResponse(BaseResponse):
     with open(resolve_schema(__file__, "version.json")) as sf:
-            schema = json.load(sf)
+        schema = json.load(sf)
 
     def __init__(
         self,

--- a/pythx/models/response/version.py
+++ b/pythx/models/response/version.py
@@ -31,13 +31,6 @@ class VersionResponse(BaseResponse):
         self.hashed_version = hashed_version
 
     @classmethod
-    def validate(cls, candidate):
-        try:
-            jsonschema.validate(candidate, cls.schema)
-        except jsonschema.ValidationError as e:
-            raise ResponseValidationError(e)
-
-    @classmethod
     def from_dict(cls, d: Dict):
         cls.validate(d)
         return cls(

--- a/pythx/models/util.py
+++ b/pythx/models/util.py
@@ -1,6 +1,6 @@
 from datetime import datetime
-from typing import Dict
 from os import path
+from typing import Dict
 
 import dateutil.parser
 

--- a/pythx/models/util.py
+++ b/pythx/models/util.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Dict
+from os import path
 
 import dateutil.parser
 
@@ -21,3 +22,7 @@ def dict_delete_none_fields(d: Dict):
         elif isinstance(v, dict):
             dict_delete_none_fields(v)
     return d
+
+
+def resolve_schema(module_path, filename):
+    return path.join(path.dirname(module_path), "schema", filename)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dateutil==2.7.5
 inflection==0.3.1
 PyJWT==1.7.1
 tabulate==0.8.3
+jsonschema==3.0.1

--- a/tests/common.py
+++ b/tests/common.py
@@ -108,7 +108,7 @@ SOURCE_LOCATION = {
     "sourceMap": SOURCE_MAP,
     "sourceType": SOURCE_TYPE,
     "sourceFormat": SOURCE_FORMAT,
-    "sourceList": [SOURCE_LIST],
+    "sourceList": SOURCE_LIST,
 }
 ISSUE_DICT = {
     "swcID": SWC_ID,
@@ -129,7 +129,7 @@ ISSUE_OBJECT = Issue(
             source_map=SOURCE_MAP,
             source_type=SourceType.RAW_BYTECODE,
             source_format=SourceFormat.EVM_BYZANTIUM_BYTECODE,
-            source_list=[SOURCE_LIST],
+            source_list=SOURCE_LIST,
         )
     ],
     extra={},
@@ -376,7 +376,7 @@ DETECTED_ISSUES_RESPONSE_DICT = [
                         "sourceMap": SOURCE_MAP,
                         "sourceType": SOURCE_TYPE,
                         "sourceFormat": SOURCE_FORMAT,
-                        "sourceList": [SOURCE_LIST],
+                        "sourceList": SOURCE_LIST,
                     }
                 ],
                 "extra": {},
@@ -384,7 +384,7 @@ DETECTED_ISSUES_RESPONSE_DICT = [
         ],
         "sourceType": SOURCE_TYPE,
         "sourceFormat": SOURCE_FORMAT,
-        "sourceList": [SOURCE_LIST],
+        "sourceList": SOURCE_LIST,
         "meta": {},
     }
 ]
@@ -392,6 +392,6 @@ DETECTED_ISSUES_RESPONSE_OBJECT = DetectedIssuesResponse(
     issues=[ISSUE_OBJECT],
     source_type=SourceType.RAW_BYTECODE,
     source_format=SourceFormat.EVM_BYZANTIUM_BYTECODE,
-    source_list=[SOURCE_LIST],
+    source_list=SOURCE_LIST,
     meta_data={},
 )

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,35 +1,35 @@
 from datetime import datetime
+
 import dateutil.parser
 
 from pythx.models.request import (
-    VersionRequest,
-    OASRequest,
-    AuthLogoutRequest,
-    AuthRefreshRequest,
-    DetectedIssuesRequest,
-    AuthLoginRequest,
     AnalysisListRequest,
     AnalysisStatusRequest,
     AnalysisSubmissionRequest,
+    AuthLoginRequest,
+    AuthLogoutRequest,
+    AuthRefreshRequest,
+    DetectedIssuesRequest,
+    OASRequest,
+    VersionRequest,
 )
 from pythx.models.response import (
-    VersionResponse,
-    OASResponse,
+    Analysis,
+    AnalysisListResponse,
+    AnalysisStatusResponse,
+    AnalysisSubmissionResponse,
+    AuthLoginResponse,
+    AuthLogoutResponse,
+    AuthRefreshResponse,
+    DetectedIssuesResponse,
     Issue,
+    OASResponse,
     Severity,
     SourceFormat,
     SourceLocation,
     SourceType,
-    DetectedIssuesResponse,
-    AuthRefreshResponse,
-    AuthLogoutResponse,
-    AuthLoginResponse,
-    AnalysisSubmissionResponse,
-    Analysis,
-    AnalysisListResponse,
-    AnalysisStatusResponse,
+    VersionResponse,
 )
-
 
 # BASE DATA
 API_VERSION_1 = "v1.3.0"

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -4,10 +4,11 @@ from copy import copy
 import dateutil.parser
 import pytest
 
-from . import common as testdata
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import Analysis, AnalysisStatus
 from pythx.models.util import deserialize_api_timestamp, serialize_api_timestamp
+
+from . import common as testdata
 
 
 def assert_analysis(analysis):

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -62,3 +62,9 @@ def test_analysis_from_invalid_dict():
 
 def test_validate():
     testdata.ANALYSIS_OBJECT.validate()
+
+
+def test_repr():
+    analysis_repr = repr(testdata.ANALYSIS_OBJECT)
+    assert testdata.ANALYSIS_OBJECT.uuid in analysis_repr
+    testdata.ANALYSIS_OBJECT.status in analysis_repr

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -5,7 +5,7 @@ import dateutil.parser
 import pytest
 
 from . import common as testdata
-from pythx.models.exceptions import ResponseDecodeError
+from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import Analysis, AnalysisStatus
 from pythx.models.util import deserialize_api_timestamp, serialize_api_timestamp
 
@@ -29,11 +29,6 @@ def test_analysis_from_valid_json():
     assert_analysis(analysis)
 
 
-def test_analysis_from_invalid_json():
-    with pytest.raises(ResponseDecodeError):
-        Analysis.from_json("{}")
-
-
 def test_analysis_to_json():
     assert json.loads(testdata.ANALYSIS_OBJECT.to_json()) == testdata.ANALYSIS_DICT
 
@@ -53,15 +48,6 @@ def test_analysis_propagate_error_field():
 def test_analysis_from_valid_dict():
     analysis = Analysis.from_dict(testdata.ANALYSIS_DICT)
     assert_analysis(analysis)
-
-
-def test_analysis_from_invalid_dict():
-    with pytest.raises(ResponseDecodeError):
-        Analysis.from_dict({})
-
-
-def test_validate():
-    testdata.ANALYSIS_OBJECT.validate()
 
 
 def test_repr():

--- a/tests/test_analysis_list_request.py
+++ b/tests/test_analysis_list_request.py
@@ -52,7 +52,3 @@ def test_analysis_list_request_to_dict():
         testdata.ANALYSIS_LIST_REQUEST_OBJECT.to_dict()
         == testdata.ANALYSIS_LIST_REQUEST_DICT
     )
-
-
-def test_validate():
-    testdata.ANALYSIS_LIST_REQUEST_OBJECT.validate()

--- a/tests/test_analysis_list_request.py
+++ b/tests/test_analysis_list_request.py
@@ -6,7 +6,6 @@ import pytest
 from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import AnalysisListRequest
 
-
 from . import common as testdata
 
 

--- a/tests/test_analysis_list_request.py
+++ b/tests/test_analysis_list_request.py
@@ -3,7 +3,7 @@ import json
 import dateutil.parser
 import pytest
 
-from pythx.models.exceptions import RequestDecodeError
+from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import AnalysisListRequest
 
 
@@ -26,7 +26,7 @@ def test_analysis_list_request_from_valid_json():
 
 
 def test_analysis_list_request_from_invalid_json():
-    with pytest.raises(RequestDecodeError):
+    with pytest.raises(RequestValidationError):
         AnalysisListRequest.from_json("{}")
 
 
@@ -36,7 +36,7 @@ def test_analysis_list_request_from_valid_dict():
 
 
 def test_analysis_list_request_from_invalid_dict():
-    with pytest.raises(RequestDecodeError):
+    with pytest.raises(RequestValidationError):
         AnalysisListRequest.from_dict({})
 
 

--- a/tests/test_analysis_list_response.py
+++ b/tests/test_analysis_list_response.py
@@ -8,7 +8,6 @@ from pythx.models.response import AnalysisListResponse
 from pythx.models.response.analysis import Analysis
 from pythx.models.util import serialize_api_timestamp
 
-
 from . import common as testdata
 
 
@@ -84,7 +83,9 @@ def test_iteration():
 
 
 def test_valid_getitem():
-    for idx, analysis in list(enumerate(testdata.ANALYSIS_LIST_RESPONSE_OBJECT.analyses)):
+    for idx, analysis in list(
+        enumerate(testdata.ANALYSIS_LIST_RESPONSE_OBJECT.analyses)
+    ):
         assert testdata.ANALYSIS_LIST_RESPONSE_OBJECT[idx] == analysis
 
 
@@ -115,7 +116,9 @@ def test_valid_setitem():
     analysis_list[0] = "foo"
     assert analysis_list.analyses[0] == "foo"
     assert analysis_list[0] == "foo"
-    assert len(analysis_list.analyses) == len(testdata.ANALYSIS_LIST_RESPONSE_OBJECT.analyses)
+    assert len(analysis_list.analyses) == len(
+        testdata.ANALYSIS_LIST_RESPONSE_OBJECT.analyses
+    )
 
 
 def test_invalid_setitem():
@@ -125,7 +128,9 @@ def test_invalid_setitem():
 
 def test_reversed():
     analysis_list = deepcopy(testdata.ANALYSIS_LIST_RESPONSE_OBJECT)
-    assert list(reversed(analysis_list)) == list(reversed(testdata.ANALYSIS_LIST_RESPONSE_OBJECT.analyses))
+    assert list(reversed(analysis_list)) == list(
+        reversed(testdata.ANALYSIS_LIST_RESPONSE_OBJECT.analyses)
+    )
     assert analysis_list.total == testdata.ANALYSIS_LIST_RESPONSE_OBJECT.total
 
 

--- a/tests/test_analysis_list_response.py
+++ b/tests/test_analysis_list_response.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 
 import pytest
 
-from pythx.models.exceptions import ResponseDecodeError, ResponseValidationError
+from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import AnalysisListResponse
 from pythx.models.response.analysis import Analysis
 from pythx.models.util import serialize_api_timestamp

--- a/tests/test_analysis_list_response.py
+++ b/tests/test_analysis_list_response.py
@@ -38,12 +38,12 @@ def test_analysis_list_from_valid_json():
 
 
 def test_analysis_list_from_invalid_json():
-    with pytest.raises(ResponseDecodeError):
+    with pytest.raises(ResponseValidationError):
         AnalysisListResponse.from_json("[]")
 
 
 def test_analysis_list_from_empty_json():
-    with pytest.raises(ResponseDecodeError):
+    with pytest.raises(ResponseValidationError):
         AnalysisListResponse.from_json("{}")
 
 
@@ -57,12 +57,12 @@ def test_analysis_list_from_valid_dict():
 
 
 def test_analysis_list_from_invalid_dict():
-    with pytest.raises(ResponseDecodeError):
+    with pytest.raises(ResponseValidationError):
         AnalysisListResponse.from_dict("[]")
 
 
 def test_analysis_list_from_empty_dict():
-    with pytest.raises(ResponseDecodeError):
+    with pytest.raises(ResponseValidationError):
         AnalysisListResponse.from_dict({})
 
 
@@ -74,17 +74,6 @@ def test_analysis_list_to_dict():
 def test_analysis_list_to_json():
     json_str = testdata.ANALYSIS_LIST_RESPONSE_OBJECT.to_json()
     assert json.loads(json_str) == testdata.ANALYSIS_LIST_RESPONSE_DICT
-
-
-def test_valid_validate():
-    testdata.ANALYSIS_LIST_RESPONSE_OBJECT.validate()
-
-
-def test_invalid_total_validate():
-    resp = deepcopy(testdata.ANALYSIS_LIST_RESPONSE_OBJECT)
-    resp.total = -1
-    with pytest.raises(ResponseValidationError):
-        resp.validate()
 
 
 def test_iteration():

--- a/tests/test_analysis_status_request.py
+++ b/tests/test_analysis_status_request.py
@@ -2,9 +2,10 @@ import json
 
 import pytest
 
-from . import common as testdata
 from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import AnalysisStatusRequest
+
+from . import common as testdata
 
 
 def assert_status_request(req: AnalysisStatusRequest):

--- a/tests/test_analysis_status_request.py
+++ b/tests/test_analysis_status_request.py
@@ -49,7 +49,3 @@ def test_analysis_status_request_to_dict():
         testdata.ANALYSIS_STATUS_REQUEST_OBJECT.to_dict()
         == testdata.ANALYSIS_STATUS_REQUEST_DICT
     )
-
-
-def test_validate():
-    testdata.ANALYSIS_STATUS_REQUEST_OBJECT.validate()

--- a/tests/test_analysis_status_request.py
+++ b/tests/test_analysis_status_request.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from . import common as testdata
-from pythx.models.exceptions import RequestDecodeError
+from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import AnalysisStatusRequest
 
 
@@ -23,7 +23,7 @@ def test_analysis_status_request_from_valid_json():
 
 
 def test_analysis_status_request_from_invalid_json():
-    with pytest.raises(RequestDecodeError):
+    with pytest.raises(RequestValidationError):
         AnalysisStatusRequest.from_json("{}")
 
 
@@ -33,7 +33,7 @@ def test_analysis_status_request_from_valid_dict():
 
 
 def test_analysis_status_request_from_invalid_dict():
-    with pytest.raises(RequestDecodeError):
+    with pytest.raises(RequestValidationError):
         AnalysisStatusRequest.from_dict({})
 
 

--- a/tests/test_analysis_status_response.py
+++ b/tests/test_analysis_status_response.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 from . import common as testdata
-from pythx.models.exceptions import ResponseDecodeError
+from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import Analysis, AnalysisStatusResponse
 from pythx.models.util import serialize_api_timestamp
 
@@ -29,7 +29,7 @@ def test_analysis_list_from_valid_json():
 
 
 def test_analysis_list_from_empty_json():
-    with pytest.raises(ResponseDecodeError):
+    with pytest.raises(ResponseValidationError):
         AnalysisStatusResponse.from_json("{}")
 
 
@@ -38,14 +38,8 @@ def test_analysis_list_from_valid_dict():
     assert_analysis_data(testdata.ANALYSIS_STATUS_RESPONSE_DICT, resp.analysis)
 
 
-def test_analysis_list_from_invalid_dict():
-    with pytest.raises(ResponseDecodeError):
-        # list of dicts expected
-        AnalysisStatusResponse.from_dict("{}")
-
-
 def test_analysis_list_from_empty_dict():
-    with pytest.raises(ResponseDecodeError):
+    with pytest.raises(ResponseValidationError):
         AnalysisStatusResponse.from_dict({})
 
 
@@ -57,7 +51,3 @@ def test_analysis_list_to_dict():
 def test_analysis_list_to_json():
     json_str = testdata.ANALYSIS_STATUS_RESPONSE_OBJECT.to_json()
     assert json.loads(json_str) == testdata.ANALYSIS_STATUS_RESPONSE_DICT
-
-
-def test_validate():
-    testdata.ANALYSIS_STATUS_RESPONSE_OBJECT.validate()

--- a/tests/test_analysis_status_response.py
+++ b/tests/test_analysis_status_response.py
@@ -1,10 +1,12 @@
 import json
 
 import pytest
-from . import common as testdata
+
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import Analysis, AnalysisStatusResponse
 from pythx.models.util import serialize_api_timestamp
+
+from . import common as testdata
 
 
 def assert_analysis_data(expected, analysis: Analysis):

--- a/tests/test_analysis_submission_request.py
+++ b/tests/test_analysis_submission_request.py
@@ -80,17 +80,13 @@ def test_analysis_submission_request_source_only():
     }
 
 
-def test_analysis_submission_request_invalid_mode():
-    req = AnalysisSubmissionRequest(bytecode=testdata.BYTECODE, analysis_mode="invalid")
-    with pytest.raises(RequestValidationError):
-        req.validate()
+# def test_analysis_submission_request_invalid_mode():
+#     req = AnalysisSubmissionRequest(bytecode=testdata.BYTECODE, analysis_mode="invalid")
+#     with pytest.raises(RequestValidationError):
+#         req.validate()
 
 
-def test_analysis_submission_request_missing_field():
-    req = AnalysisSubmissionRequest()
-    with pytest.raises(RequestValidationError):
-        req.validate()
-
-
-def test_validate():
-    testdata.ANALYSIS_SUBMISSION_REQUEST_OBJECT.validate()
+# def test_analysis_submission_request_missing_field():
+#     req = AnalysisSubmissionRequest()
+#     with pytest.raises(RequestValidationError):
+#         req.validate()

--- a/tests/test_analysis_submission_request.py
+++ b/tests/test_analysis_submission_request.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from . import common as testdata
-from pythx.models.exceptions import RequestDecodeError, RequestValidationError
+from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import AnalysisSubmissionRequest
 
 
@@ -30,7 +30,7 @@ def test_analysis_submission_request_from_valid_json():
 
 
 def test_analysis_submission_request_from_invalid_json():
-    with pytest.raises(RequestDecodeError):
+    with pytest.raises(RequestValidationError):
         AnalysisSubmissionRequest.from_json("{}")
 
 
@@ -40,7 +40,7 @@ def test_analysis_submission_request_from_valid_dict():
 
 
 def test_analysis_submission_request_from_invalid_dict():
-    with pytest.raises(RequestDecodeError):
+    with pytest.raises(RequestValidationError):
         AnalysisSubmissionRequest.from_dict({})
 
 
@@ -80,13 +80,13 @@ def test_analysis_submission_request_source_only():
     }
 
 
-# def test_analysis_submission_request_invalid_mode():
-#     req = AnalysisSubmissionRequest(bytecode=testdata.BYTECODE, analysis_mode="invalid")
-#     with pytest.raises(RequestValidationError):
-#         req.validate()
+def test_analysis_submission_request_invalid_mode():
+    req = AnalysisSubmissionRequest(bytecode=testdata.BYTECODE, analysis_mode="invalid")
+    with pytest.raises(RequestValidationError):
+        req.to_dict()
 
 
-# def test_analysis_submission_request_missing_field():
-#     req = AnalysisSubmissionRequest()
-#     with pytest.raises(RequestValidationError):
-#         req.validate()
+def test_analysis_submission_request_missing_field():
+    req = AnalysisSubmissionRequest()
+    with pytest.raises(RequestValidationError):
+        req.to_dict()

--- a/tests/test_analysis_submission_request.py
+++ b/tests/test_analysis_submission_request.py
@@ -2,9 +2,10 @@ import json
 
 import pytest
 
-from . import common as testdata
 from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import AnalysisSubmissionRequest
+
+from . import common as testdata
 
 
 def assert_submission_request(req: AnalysisSubmissionRequest):

--- a/tests/test_analysis_submission_response.py
+++ b/tests/test_analysis_submission_response.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from . import common as testdata
-from pythx.models.exceptions import ResponseDecodeError
+from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import Analysis, AnalysisSubmissionResponse
 from pythx.models.util import serialize_api_timestamp
 
@@ -30,7 +30,7 @@ def test_analysis_submission_from_valid_json():
 
 
 def test_analysis_submission_from_empty_json():
-    with pytest.raises(ResponseDecodeError):
+    with pytest.raises(ResponseValidationError):
         AnalysisSubmissionResponse.from_json("{}")
 
 
@@ -41,14 +41,8 @@ def test_analysis_submission_from_valid_dict():
     assert_analysis_data(testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT, resp.analysis)
 
 
-def test_analysis_submission_from_invalid_dict():
-    with pytest.raises(ResponseDecodeError):
-        # list of dicts expected
-        AnalysisSubmissionResponse.from_dict("{}")
-
-
 def test_analysis_submission_from_empty_dict():
-    with pytest.raises(ResponseDecodeError):
+    with pytest.raises(ResponseValidationError):
         AnalysisSubmissionResponse.from_dict({})
 
 

--- a/tests/test_analysis_submission_response.py
+++ b/tests/test_analysis_submission_response.py
@@ -22,41 +22,48 @@ def assert_analysis_data(expected, analysis: Analysis):
     assert expected["uuid"] == analysis.uuid
 
 
-def test_analysis_list_from_valid_json():
+def test_analysis_submission_from_valid_json():
     resp = AnalysisSubmissionResponse.from_json(
         json.dumps(testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT)
     )
     assert_analysis_data(testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT, resp.analysis)
 
 
-def test_analysis_list_from_empty_json():
+def test_analysis_submission_from_empty_json():
     with pytest.raises(ResponseDecodeError):
         AnalysisSubmissionResponse.from_json("{}")
 
 
-def test_analysis_list_from_valid_dict():
+def test_analysis_submission_from_valid_dict():
     resp = AnalysisSubmissionResponse.from_dict(
         testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT
     )
     assert_analysis_data(testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT, resp.analysis)
 
 
-def test_analysis_list_from_invalid_dict():
+def test_analysis_submission_from_invalid_dict():
     with pytest.raises(ResponseDecodeError):
         # list of dicts expected
         AnalysisSubmissionResponse.from_dict("{}")
 
 
-def test_analysis_list_from_empty_dict():
+def test_analysis_submission_from_empty_dict():
     with pytest.raises(ResponseDecodeError):
         AnalysisSubmissionResponse.from_dict({})
 
 
-def test_analysis_list_to_dict():
+def test_analysis_submission_to_dict():
     d = testdata.ANALYSIS_SUBMISSION_RESPONSE_OBJECT.to_dict()
     assert d == testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT
 
 
-def test_analysis_list_to_json():
+def test_analysis_submission_to_json():
     json_str = testdata.ANALYSIS_SUBMISSION_RESPONSE_OBJECT.to_json()
     assert json.loads(json_str) == testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT
+
+
+def test_analysis_submission_property_delegation():
+    assert_analysis_data(
+        testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT,
+        testdata.ANALYSIS_SUBMISSION_RESPONSE_OBJECT
+    )

--- a/tests/test_analysis_submission_response.py
+++ b/tests/test_analysis_submission_response.py
@@ -2,10 +2,11 @@ import json
 
 import pytest
 
-from . import common as testdata
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import Analysis, AnalysisSubmissionResponse
 from pythx.models.util import serialize_api_timestamp
+
+from . import common as testdata
 
 
 def assert_analysis_data(expected, analysis: Analysis):
@@ -59,5 +60,5 @@ def test_analysis_submission_to_json():
 def test_analysis_submission_property_delegation():
     assert_analysis_data(
         testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT,
-        testdata.ANALYSIS_SUBMISSION_RESPONSE_OBJECT
+        testdata.ANALYSIS_SUBMISSION_RESPONSE_OBJECT,
     )

--- a/tests/test_api_handler.py
+++ b/tests/test_api_handler.py
@@ -4,13 +4,14 @@ from datetime import datetime
 import dateutil.parser
 import pytest
 
-from . import common as testdata
 from pythx import config
 from pythx.api.handler import APIHandler
 from pythx.middleware.base import BaseMiddleware
 from pythx.models import request as reqmodels
 from pythx.models import response as respmodels
 from pythx.models.exceptions import PythXAPIError
+
+from . import common as testdata
 
 
 class TestMiddleware(BaseMiddleware):

--- a/tests/test_auth_login_request.py
+++ b/tests/test_auth_login_request.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from . import common as testdata
-from pythx.models.exceptions import RequestDecodeError
+from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import AuthLoginRequest
 
 
@@ -22,7 +22,7 @@ def test_login_from_valid_json():
 
 
 def test_login_from_invalid_json():
-    with pytest.raises(RequestDecodeError):
+    with pytest.raises(RequestValidationError):
         AuthLoginRequest.from_json("{}")
 
 
@@ -32,7 +32,7 @@ def test_login_from_valid_dict():
 
 
 def test_login_from_invalid_dict():
-    with pytest.raises(RequestDecodeError):
+    with pytest.raises(RequestValidationError):
         AuthLoginRequest.from_dict({})
 
 

--- a/tests/test_auth_login_request.py
+++ b/tests/test_auth_login_request.py
@@ -45,7 +45,3 @@ def test_login_to_json():
 
 def test_login_to_dict():
     assert testdata.LOGIN_REQUEST_OBJECT.to_dict() == testdata.LOGIN_REQUEST_DICT
-
-
-def test_validate():
-    testdata.LOGIN_REQUEST_OBJECT.validate()

--- a/tests/test_auth_login_request.py
+++ b/tests/test_auth_login_request.py
@@ -2,9 +2,10 @@ import json
 
 import pytest
 
-from . import common as testdata
 from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import AuthLoginRequest
+
+from . import common as testdata
 
 
 def assert_login(req: AuthLoginRequest):

--- a/tests/test_auth_login_response.py
+++ b/tests/test_auth_login_response.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from . import common as testdata
-from pythx.models.exceptions import ResponseDecodeError
+from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import AuthLoginResponse
 
 
@@ -18,7 +18,7 @@ def test_auth_login_response_from_valid_json():
 
 
 def test_auth_login_response_from_invalid_json():
-    with pytest.raises(ResponseDecodeError):
+    with pytest.raises(ResponseValidationError):
         AuthLoginResponse.from_json("{}")
 
 
@@ -28,7 +28,7 @@ def test_auth_login_response_from_valid_dict():
 
 
 def test_auth_login_response_from_invalid_dict():
-    with pytest.raises(ResponseDecodeError):
+    with pytest.raises(ResponseValidationError):
         AuthLoginResponse.from_dict({})
 
 
@@ -41,7 +41,3 @@ def test_auth_login_response_to_json():
 
 def test_auth_login_response_to_dict():
     assert testdata.LOGIN_RESPONSE_OBJECT.to_dict() == testdata.LOGIN_RESPONSE_DICT
-
-
-def test_validate():
-    testdata.LOGIN_RESPONSE_OBJECT.validate()

--- a/tests/test_auth_login_response.py
+++ b/tests/test_auth_login_response.py
@@ -2,9 +2,10 @@ import json
 
 import pytest
 
-from . import common as testdata
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import AuthLoginResponse
+
+from . import common as testdata
 
 
 def assert_auth_login_response(resp: AuthLoginResponse):

--- a/tests/test_auth_logout_request.py
+++ b/tests/test_auth_logout_request.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from . import common as testdata
-from pythx.models.exceptions import RequestDecodeError
+from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import AuthLogoutRequest
 
 
@@ -21,7 +21,7 @@ def test_auth_logout_request_from_valid_json():
 
 
 def test_auth_logout_request_from_invalid_json():
-    with pytest.raises(RequestDecodeError):
+    with pytest.raises(RequestValidationError):
         AuthLogoutRequest.from_json("{}")
 
 
@@ -31,7 +31,7 @@ def test_auth_logout_request_from_valid_dict():
 
 
 def test_auth_logout_request_from_invalid_dict():
-    with pytest.raises(RequestDecodeError):
+    with pytest.raises(RequestValidationError):
         AuthLogoutRequest.from_dict({})
 
 

--- a/tests/test_auth_logout_request.py
+++ b/tests/test_auth_logout_request.py
@@ -2,9 +2,10 @@ import json
 
 import pytest
 
-from . import common as testdata
 from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import AuthLogoutRequest
+
+from . import common as testdata
 
 
 def assert_logout_request(req):

--- a/tests/test_auth_logout_request.py
+++ b/tests/test_auth_logout_request.py
@@ -44,7 +44,3 @@ def test_auth_logout_request_to_json():
 
 def test_auth_logout_request_to_dict():
     assert testdata.LOGOUT_REQUEST_OBJECT.to_dict() == testdata.LOGOUT_REQUEST_DICT
-
-
-def test_validate():
-    testdata.LOGOUT_REQUEST_OBJECT.validate()

--- a/tests/test_auth_logout_response.py
+++ b/tests/test_auth_logout_response.py
@@ -2,9 +2,10 @@ import json
 
 import pytest
 
-from . import common as testdata
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import AuthLogoutResponse
+
+from . import common as testdata
 
 
 def test_auth_login_response_from_valid_json():

--- a/tests/test_auth_logout_response.py
+++ b/tests/test_auth_logout_response.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from . import common as testdata
-from pythx.models.exceptions import ResponseDecodeError
+from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import AuthLogoutResponse
 
 
@@ -13,7 +13,7 @@ def test_auth_login_response_from_valid_json():
 
 
 def test_auth_login_response_from_invalid_json():
-    with pytest.raises(ResponseDecodeError):
+    with pytest.raises(ResponseValidationError):
         AuthLogoutResponse.from_json('{"foo": "bar"}')
 
 
@@ -23,7 +23,7 @@ def test_auth_login_response_from_valid_dict():
 
 
 def test_auth_login_response_from_invalid_dict():
-    with pytest.raises(ResponseDecodeError):
+    with pytest.raises(ResponseValidationError):
         AuthLogoutResponse.from_dict({"foo": "bar"})
 
 
@@ -33,7 +33,3 @@ def test_auth_login_response_to_json():
 
 def test_auth_login_response_to_dict():
     assert testdata.LOGOUT_RESPONSE_OBJECT.to_dict() == {}
-
-
-def test_validate():
-    testdata.LOGOUT_RESPONSE_OBJECT.validate()

--- a/tests/test_auth_refresh_request.py
+++ b/tests/test_auth_refresh_request.py
@@ -2,9 +2,10 @@ import json
 
 import pytest
 
-from . import common as testdata
 from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import AuthRefreshRequest
+
+from . import common as testdata
 
 
 def assert_auth_refresh_request(req: AuthRefreshRequest):

--- a/tests/test_auth_refresh_request.py
+++ b/tests/test_auth_refresh_request.py
@@ -45,7 +45,3 @@ def test_auth_refresh_request_to_json():
 
 def test_auth_refresh_request_to_dict():
     assert testdata.REFRESH_REQUEST_OBJECT.to_dict() == testdata.REFRESH_REQUEST_DICT
-
-
-def test_validate():
-    testdata.REFRESH_REQUEST_OBJECT.validate()

--- a/tests/test_auth_refresh_request.py
+++ b/tests/test_auth_refresh_request.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from . import common as testdata
-from pythx.models.exceptions import RequestDecodeError
+from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import AuthRefreshRequest
 
 
@@ -22,7 +22,7 @@ def test_auth_refresh_request_from_valid_json():
 
 
 def test_auth_refresh_request_from_invalid_json():
-    with pytest.raises(RequestDecodeError):
+    with pytest.raises(RequestValidationError):
         AuthRefreshRequest.from_json("{}")
 
 
@@ -32,7 +32,7 @@ def test_auth_refresh_request_from_valid_dict():
 
 
 def test_auth_refresh_request_from_invalid_dict():
-    with pytest.raises(RequestDecodeError):
+    with pytest.raises(RequestValidationError):
         AuthRefreshRequest.from_dict({})
 
 

--- a/tests/test_auth_refresh_response.py
+++ b/tests/test_auth_refresh_response.py
@@ -2,9 +2,10 @@ import json
 
 import pytest
 
-from . import common as testdata
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import AuthRefreshResponse
+
+from . import common as testdata
 
 ACCESS_TOKEN = "my_fancy_access_token"
 REFRESH_TOKEN = "my_fancy_refresh_token"

--- a/tests/test_auth_refresh_response.py
+++ b/tests/test_auth_refresh_response.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from . import common as testdata
-from pythx.models.exceptions import ResponseDecodeError
+from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import AuthRefreshResponse
 
 ACCESS_TOKEN = "my_fancy_access_token"
@@ -25,7 +25,7 @@ def test_auth_refresh_response_from_valid_json():
 
 
 def test_auth_refresh_response_from_invalid_json():
-    with pytest.raises(ResponseDecodeError):
+    with pytest.raises(ResponseValidationError):
         AuthRefreshResponse.from_json("{}")
 
 
@@ -35,7 +35,7 @@ def test_auth_refresh_response_from_valid_dict():
 
 
 def test_auth_refresh_response_from_invalid_dict():
-    with pytest.raises(ResponseDecodeError):
+    with pytest.raises(ResponseValidationError):
         AuthRefreshResponse.from_dict({})
 
 
@@ -48,7 +48,3 @@ def test_auth_refresh_response_to_json():
 
 def test_auth_refresh_response_to_dict():
     assert testdata.REFRESH_RESPONSE_OBJECT.to_dict() == testdata.REFRESH_RESPONSE_DICT
-
-
-def test_validate():
-    testdata.REFRESH_RESPONSE_OBJECT.validate()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -278,3 +278,8 @@ def test_jwt_expiration():
     assert Client._get_jwt_expiration_ts(testdata.REFRESH_TOKEN_1) == datetime(
         2019, 3, 24, 16, 21, 19, 28000
     )
+
+
+def test_context_handler():
+    with get_client([testdata.LOGOUT_RESPONSE_DICT]) as c:
+        pass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -164,7 +164,7 @@ def test_analyze_bytecode():
 
 def test_analyze_source_code():
     client = get_client([testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT])
-    resp = client.analyze(sources={"foo.sol": "bar"})
+    resp = client.analyze(sources={"foo.sol": {"source": "bar"}})
 
     assert type(resp) == respmodels.AnalysisSubmissionResponse
     assert_analysis(resp.analysis)
@@ -172,21 +172,21 @@ def test_analyze_source_code():
 
 def test_analyze_source_and_bytecode():
     client = get_client([testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT])
-    resp = client.analyze(sources={"foo.sol": "bar"}, bytecode="0xf00")
+    resp = client.analyze(sources={"foo.sol": {"source": "bar"}}, bytecode="0xf00")
     assert type(resp) == respmodels.AnalysisSubmissionResponse
     assert_analysis(resp.analysis)
 
 
-# def test_analyze_missing_data():
-#     client = get_client([testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT])
-#     with pytest.raises(RequestValidationError):
-#         client.analyze()
+def test_analyze_missing_data():
+    client = get_client([testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT])
+    with pytest.raises(RequestValidationError):
+        client.analyze()
 
 
-# def test_analyze_invalid_mode():
-#     client = get_client([testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT])
-#     with pytest.raises(RequestValidationError):
-#         client.analyze(bytecode="0xf00", analysis_mode="invalid")
+def test_analyze_invalid_mode():
+    client = get_client([testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT])
+    with pytest.raises(RequestValidationError):
+        client.analyze(bytecode="0xf00", analysis_mode="invalid")
 
 
 def test_status():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -177,16 +177,16 @@ def test_analyze_source_and_bytecode():
     assert_analysis(resp.analysis)
 
 
-def test_analyze_missing_data():
-    client = get_client([testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT])
-    with pytest.raises(RequestValidationError):
-        client.analyze()
+# def test_analyze_missing_data():
+#     client = get_client([testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT])
+#     with pytest.raises(RequestValidationError):
+#         client.analyze()
 
 
-def test_analyze_invalid_mode():
-    client = get_client([testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT])
-    with pytest.raises(RequestValidationError):
-        client.analyze(bytecode="0xf00", analysis_mode="invalid")
+# def test_analyze_invalid_mode():
+#     client = get_client([testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT])
+#     with pytest.raises(RequestValidationError):
+#         client.analyze(bytecode="0xf00", analysis_mode="invalid")
 
 
 def test_status():
@@ -233,7 +233,7 @@ def test_report():
     assert type(resp) == respmodels.DetectedIssuesResponse
     assert resp.source_type == testdata.SOURCE_TYPE
     assert resp.source_format == testdata.SOURCE_FORMAT
-    assert resp.source_list == [testdata.SOURCE_LIST]
+    assert resp.source_list == testdata.SOURCE_LIST
     assert resp.meta_data == {}
     assert len(resp.issues) == 1
     issue = resp.issues[0]
@@ -248,7 +248,7 @@ def test_report():
     assert location.source_map == testdata.SOURCE_MAP
     assert location.source_type == testdata.SOURCE_TYPE
     assert location.source_format == testdata.SOURCE_FORMAT
-    assert location.source_list == [testdata.SOURCE_LIST]
+    assert location.source_list == testdata.SOURCE_LIST
 
 
 def test_openapi():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,17 +1,19 @@
 import json
-import jwt
 from copy import copy
 from datetime import datetime, timedelta
+
+import jwt
+import pytest
 from dateutil.tz import tzutc
 
-import pytest
-from . import common as testdata
 import pythx.models.response as respmodels
 from pythx import config
 from pythx.api import APIHandler, Client
 from pythx.models.exceptions import PythXAPIError, RequestValidationError
 from pythx.models.response.analysis import AnalysisStatus
 from pythx.models.util import serialize_api_timestamp
+
+from . import common as testdata
 
 
 class MockAPIHandler(APIHandler):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -282,4 +282,4 @@ def test_jwt_expiration():
 
 def test_context_handler():
     with get_client([testdata.LOGOUT_RESPONSE_DICT]) as c:
-        pass
+        assert c is not None

--- a/tests/test_detected_issues_request.py
+++ b/tests/test_detected_issues_request.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from . import common as testdata
-from pythx.models.exceptions import RequestDecodeError
+from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import DetectedIssuesRequest
 
 
@@ -19,7 +19,7 @@ def test_analysis_issues_request_from_valid_json():
 
 
 def test_analysis_issues_request_from_invalid_json():
-    with pytest.raises(RequestDecodeError):
+    with pytest.raises(RequestValidationError):
         DetectedIssuesRequest.from_json("{}")
 
 
@@ -29,7 +29,7 @@ def test_analysis_issues_request_from_valid_dict():
 
 
 def test_analysis_issues_request_from_invalid_dict():
-    with pytest.raises(RequestDecodeError):
+    with pytest.raises(RequestValidationError):
         DetectedIssuesRequest.from_dict({})
 
 

--- a/tests/test_detected_issues_request.py
+++ b/tests/test_detected_issues_request.py
@@ -2,9 +2,10 @@ import json
 
 import pytest
 
-from . import common as testdata
 from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import DetectedIssuesRequest
+
+from . import common as testdata
 
 
 def test_analysis_issues_request_from_valid_json():

--- a/tests/test_detected_issues_request.py
+++ b/tests/test_detected_issues_request.py
@@ -45,7 +45,3 @@ def test_analysis_issues_request_to_dict():
         testdata.DETECTED_ISSUES_REQUEST_OBJECT.to_dict()
         == testdata.DETECTED_ISSUES_REQUEST_DICT
     )
-
-
-def test_validate():
-    testdata.DETECTED_ISSUES_REQUEST_OBJECT.validate()

--- a/tests/test_detected_issues_response.py
+++ b/tests/test_detected_issues_response.py
@@ -89,3 +89,7 @@ def test_response_length():
     assert len(resp) == len(resp.issues)
     resp.issues.append("foo")
     assert len(resp) == len(resp.issues)
+
+def test_issue_iterator():
+    for i, issue in enumerate(testdata.DETECTED_ISSUES_RESPONSE_OBJECT):
+        assert testdata.DETECTED_ISSUES_RESPONSE_OBJECT.issues[i] == issue

--- a/tests/test_detected_issues_response.py
+++ b/tests/test_detected_issues_response.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+from copy import deepcopy
 from . import common as testdata
 from pythx.models.exceptions import ResponseDecodeError
 from pythx.models.response import (
@@ -82,3 +83,9 @@ def test_valid_swc_id_not_contains():
 def test_invalid_key_contains():
     with pytest.raises(ValueError):
         1337 in testdata.DETECTED_ISSUES_RESPONSE_OBJECT
+
+def test_response_length():
+    resp = deepcopy(testdata.DETECTED_ISSUES_RESPONSE_OBJECT)
+    assert len(resp) == len(resp.issues)
+    resp.issues.append("foo")
+    assert len(resp) == len(resp.issues)

--- a/tests/test_detected_issues_response.py
+++ b/tests/test_detected_issues_response.py
@@ -4,7 +4,7 @@ import pytest
 
 from copy import deepcopy
 from . import common as testdata
-from pythx.models.exceptions import ResponseDecodeError
+from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import (
     DetectedIssuesResponse,
     Issue,
@@ -28,7 +28,7 @@ def assert_detected_issues(resp):
     assert location.source_map == testdata.SOURCE_MAP
     assert location.source_format == SourceFormat.EVM_BYZANTIUM_BYTECODE
     assert location.source_type == SourceType.RAW_BYTECODE
-    assert location.source_list == [testdata.SOURCE_LIST]
+    assert location.source_list == testdata.SOURCE_LIST
 
 
 def test_detected_issues_from_valid_json():
@@ -39,7 +39,7 @@ def test_detected_issues_from_valid_json():
 
 
 def test_detected_issues_from_invalid_json():
-    with pytest.raises(ResponseDecodeError):
+    with pytest.raises(ResponseValidationError):
         DetectedIssuesResponse.from_json("[]")
 
 
@@ -49,12 +49,12 @@ def test_detected_issues_from_dict():
 
 
 def test_detected_issues_from_invalid_list():
-    with pytest.raises(ResponseDecodeError):
+    with pytest.raises(ResponseValidationError):
         DetectedIssuesResponse.from_dict([])
 
 
 def test_detected_issues_from_invalid_dict():
-    with pytest.raises(ResponseDecodeError):
+    with pytest.raises(ResponseValidationError):
         DetectedIssuesResponse.from_dict({})
 
 
@@ -66,10 +66,6 @@ def test_detected_issues_to_json():
 def test_detected_issues_to_dict():
     resp = testdata.DETECTED_ISSUES_RESPONSE_OBJECT.to_dict()
     assert testdata.DETECTED_ISSUES_RESPONSE_DICT == resp
-
-
-def test_validate():
-    testdata.DETECTED_ISSUES_RESPONSE_OBJECT.validate()
 
 
 def test_valid_swc_id_contains():

--- a/tests/test_detected_issues_response.py
+++ b/tests/test_detected_issues_response.py
@@ -93,3 +93,30 @@ def test_response_length():
 def test_issue_iterator():
     for i, issue in enumerate(testdata.DETECTED_ISSUES_RESPONSE_OBJECT):
         assert testdata.DETECTED_ISSUES_RESPONSE_OBJECT.issues[i] == issue
+
+def test_issue_valid_getitem():
+    assert testdata.DETECTED_ISSUES_RESPONSE_OBJECT[0] == testdata.DETECTED_ISSUES_RESPONSE_OBJECT.issues[0]
+
+def test_invalid_getitem():
+    with pytest.raises(IndexError):
+        testdata.DETECTED_ISSUES_RESPONSE_OBJECT[1337]
+
+def test_valid_setitem():
+    resp = deepcopy(testdata.DETECTED_ISSUES_RESPONSE_OBJECT)
+    resp[0] = "foo"
+    assert resp[0] == "foo"
+    assert resp.issues[0] == "foo"
+
+def test_invalid_setitem():
+    with pytest.raises(TypeError):
+        # string key on list access
+        testdata.DETECTED_ISSUES_RESPONSE_OBJECT["foo"]
+
+def test_valid_delete():
+    resp = deepcopy(testdata.DETECTED_ISSUES_RESPONSE_OBJECT)
+    del resp[0]
+    assert resp.issues == []
+
+def test_invalid_delete():
+    with pytest.raises(IndexError):
+        del testdata.DETECTED_ISSUES_RESPONSE_OBJECT[1337]

--- a/tests/test_detected_issues_response.py
+++ b/tests/test_detected_issues_response.py
@@ -1,9 +1,8 @@
 import json
+from copy import deepcopy
 
 import pytest
 
-from copy import deepcopy
-from . import common as testdata
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import (
     DetectedIssuesResponse,
@@ -13,6 +12,8 @@ from pythx.models.response import (
     SourceLocation,
     SourceType,
 )
+
+from . import common as testdata
 
 
 def assert_detected_issues(resp):
@@ -80,22 +81,30 @@ def test_invalid_key_contains():
     with pytest.raises(ValueError):
         1337 in testdata.DETECTED_ISSUES_RESPONSE_OBJECT
 
+
 def test_response_length():
     resp = deepcopy(testdata.DETECTED_ISSUES_RESPONSE_OBJECT)
     assert len(resp) == len(resp.issues)
     resp.issues.append("foo")
     assert len(resp) == len(resp.issues)
 
+
 def test_issue_iterator():
     for i, issue in enumerate(testdata.DETECTED_ISSUES_RESPONSE_OBJECT):
         assert testdata.DETECTED_ISSUES_RESPONSE_OBJECT.issues[i] == issue
 
+
 def test_issue_valid_getitem():
-    assert testdata.DETECTED_ISSUES_RESPONSE_OBJECT[0] == testdata.DETECTED_ISSUES_RESPONSE_OBJECT.issues[0]
+    assert (
+        testdata.DETECTED_ISSUES_RESPONSE_OBJECT[0]
+        == testdata.DETECTED_ISSUES_RESPONSE_OBJECT.issues[0]
+    )
+
 
 def test_invalid_getitem():
     with pytest.raises(IndexError):
         testdata.DETECTED_ISSUES_RESPONSE_OBJECT[1337]
+
 
 def test_valid_setitem():
     resp = deepcopy(testdata.DETECTED_ISSUES_RESPONSE_OBJECT)
@@ -103,15 +112,18 @@ def test_valid_setitem():
     assert resp[0] == "foo"
     assert resp.issues[0] == "foo"
 
+
 def test_invalid_setitem():
     with pytest.raises(TypeError):
         # string key on list access
         testdata.DETECTED_ISSUES_RESPONSE_OBJECT["foo"]
 
+
 def test_valid_delete():
     resp = deepcopy(testdata.DETECTED_ISSUES_RESPONSE_OBJECT)
     del resp[0]
     assert resp.issues == []
+
 
 def test_invalid_delete():
     with pytest.raises(IndexError):

--- a/tests/test_detected_issues_response.py
+++ b/tests/test_detected_issues_response.py
@@ -69,3 +69,16 @@ def test_detected_issues_to_dict():
 
 def test_validate():
     testdata.DETECTED_ISSUES_RESPONSE_OBJECT.validate()
+
+
+def test_valid_swc_id_contains():
+    assert testdata.SWC_ID in testdata.DETECTED_ISSUES_RESPONSE_OBJECT
+
+
+def test_valid_swc_id_not_contains():
+    assert not "SWC-104" in testdata.DETECTED_ISSUES_RESPONSE_OBJECT
+
+
+def test_invalid_key_contains():
+    with pytest.raises(ValueError):
+        1337 in testdata.DETECTED_ISSUES_RESPONSE_OBJECT

--- a/tests/test_issue.py
+++ b/tests/test_issue.py
@@ -2,7 +2,6 @@ import json
 
 import pytest
 
-from . import common as testdata
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import (
     Issue,
@@ -11,6 +10,8 @@ from pythx.models.response import (
     SourceLocation,
     SourceType,
 )
+
+from . import common as testdata
 
 
 def assert_issue(issue: Issue):

--- a/tests/test_issue.py
+++ b/tests/test_issue.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from . import common as testdata
-from pythx.models.exceptions import ResponseDecodeError
+from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import (
     Issue,
     Severity,
@@ -24,7 +24,7 @@ def assert_issue(issue: Issue):
     assert location.source_map == testdata.SOURCE_MAP
     assert location.source_format == SourceFormat.EVM_BYZANTIUM_BYTECODE
     assert location.source_type == SourceType.RAW_BYTECODE
-    assert location.source_list == [testdata.SOURCE_LIST]
+    assert location.source_list == testdata.SOURCE_LIST
 
 
 def test_issue_from_valid_json():
@@ -48,15 +48,6 @@ def test_issue_to_dict():
 def test_source_location_from_dict():
     sl = SourceLocation.from_dict(testdata.SOURCE_LOCATION)
     assert sl.source_format == testdata.SOURCE_FORMAT
-    assert sl.source_list == [testdata.SOURCE_LIST]
+    assert sl.source_list == testdata.SOURCE_LIST
     assert sl.source_map == testdata.SOURCE_MAP
     assert sl.source_type == testdata.SOURCE_TYPE
-
-
-def test_source_location_from_invalid_dict():
-    with pytest.raises(ResponseDecodeError):
-        SourceLocation.from_dict({})
-
-
-def test_source_location_validate():
-    SourceLocation.from_dict(testdata.SOURCE_LOCATION).validate()

--- a/tests/test_model_validator_errors.py
+++ b/tests/test_model_validator_errors.py
@@ -2,41 +2,32 @@ import pytest
 
 from pythx.models import response as respmodels
 from pythx.models import request as reqmodels
+from pythx.models.exceptions import RequestValidationError, ResponseValidationError
 from . import common as testdata
 
 
-def generate_request_dict(req):
-    return {
-        "method": req.method,
-        "payload": req.payload,
-        "params": req.parameters,
-        "headers": req.headers,
-        "url": "https://test.com/" + req.endpoint,
-    }
-
-
 @pytest.mark.parametrize(
-    "r_dict,model,should_raise",
+    "r_dict,model,should_raise,exc",
     [
-        (testdata.ANALYSIS_LIST_REQUEST_DICT, reqmodels.AnalysisListRequest, True),
-        (testdata.DETECTED_ISSUES_REQUEST_DICT, reqmodels.DetectedIssuesRequest, True),
-        (testdata.ANALYSIS_STATUS_REQUEST_DICT, reqmodels.AnalysisStatusRequest, True),
-        (testdata.ANALYSIS_SUBMISSION_REQUEST_DICT, reqmodels.AnalysisSubmissionRequest, False),
-        (testdata.LOGIN_REQUEST_DICT, reqmodels.AuthLoginRequest, False),
-        (testdata.LOGOUT_REQUEST_DICT, reqmodels.AuthLogoutRequest, False),
-        (testdata.REFRESH_REQUEST_DICT, reqmodels.AuthRefreshRequest, False),
-        (testdata.ANALYSIS_LIST_RESPONSE_DICT, respmodels.AnalysisListResponse, False),
-        (testdata.DETECTED_ISSUES_RESPONSE_DICT, respmodels.DetectedIssuesResponse, False),
-        (testdata.ANALYSIS_STATUS_RESPONSE_DICT, respmodels.AnalysisStatusResponse, False),
-        (testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT, respmodels.AnalysisSubmissionResponse, False),
-        (testdata.LOGIN_RESPONSE_DICT, respmodels.AuthLoginResponse, False),
-        (testdata.LOGOUT_RESPONSE_DICT, respmodels.AuthLogoutResponse, True),
-        (testdata.REFRESH_RESPONSE_DICT, respmodels.AuthRefreshResponse, False),
+        (testdata.ANALYSIS_LIST_REQUEST_DICT, reqmodels.AnalysisListRequest, False, RequestValidationError),
+        (testdata.DETECTED_ISSUES_REQUEST_DICT, reqmodels.DetectedIssuesRequest, False, RequestValidationError),
+        (testdata.ANALYSIS_STATUS_REQUEST_DICT, reqmodels.AnalysisStatusRequest, False, RequestValidationError),
+        (testdata.ANALYSIS_SUBMISSION_REQUEST_DICT, reqmodels.AnalysisSubmissionRequest, True, RequestValidationError),
+        (testdata.LOGIN_REQUEST_DICT, reqmodels.AuthLoginRequest, True, RequestValidationError),
+        (testdata.LOGOUT_REQUEST_DICT, reqmodels.AuthLogoutRequest, True, RequestValidationError),
+        (testdata.REFRESH_REQUEST_DICT, reqmodels.AuthRefreshRequest, True, RequestValidationError),
+        (testdata.ANALYSIS_LIST_RESPONSE_DICT, respmodels.AnalysisListResponse, True, ResponseValidationError),
+        (testdata.DETECTED_ISSUES_RESPONSE_DICT, respmodels.DetectedIssuesResponse, True, ResponseValidationError),
+        (testdata.ANALYSIS_STATUS_RESPONSE_DICT, respmodels.AnalysisStatusResponse, True, ResponseValidationError),
+        (testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT, respmodels.AnalysisSubmissionResponse, True, ResponseValidationError),
+        (testdata.LOGIN_RESPONSE_DICT, respmodels.AuthLoginResponse, True, ResponseValidationError),
+        (testdata.LOGOUT_RESPONSE_DICT, respmodels.AuthLogoutResponse, False, ResponseValidationError),
+        (testdata.REFRESH_RESPONSE_DICT, respmodels.AuthRefreshResponse, True, ResponseValidationError),
     ],
 )
-def test_model_validators(r_dict, model, should_raise):
+def test_model_validators(r_dict, model, should_raise, exc):
     if should_raise:
-        with pytest.raises(TypeError):
-            model.validate(r_dict)
+        with pytest.raises(exc):
+            model.validate({})
     else:
         model.validate(r_dict)

--- a/tests/test_model_validator_errors.py
+++ b/tests/test_model_validator_errors.py
@@ -1,0 +1,42 @@
+import pytest
+
+from pythx.models import response as respmodels
+from pythx.models import request as reqmodels
+from . import common as testdata
+
+
+def generate_request_dict(req):
+    return {
+        "method": req.method,
+        "payload": req.payload,
+        "params": req.parameters,
+        "headers": req.headers,
+        "url": "https://test.com/" + req.endpoint,
+    }
+
+
+@pytest.mark.parametrize(
+    "r_dict,model,should_raise",
+    [
+        (testdata.ANALYSIS_LIST_REQUEST_DICT, reqmodels.AnalysisListRequest, True),
+        (testdata.DETECTED_ISSUES_REQUEST_DICT, reqmodels.DetectedIssuesRequest, True),
+        (testdata.ANALYSIS_STATUS_REQUEST_DICT, reqmodels.AnalysisStatusRequest, True),
+        (testdata.ANALYSIS_SUBMISSION_REQUEST_DICT, reqmodels.AnalysisSubmissionRequest, False),
+        (testdata.LOGIN_REQUEST_DICT, reqmodels.AuthLoginRequest, False),
+        (testdata.LOGOUT_REQUEST_DICT, reqmodels.AuthLogoutRequest, False),
+        (testdata.REFRESH_REQUEST_DICT, reqmodels.AuthRefreshRequest, False),
+        (testdata.ANALYSIS_LIST_RESPONSE_DICT, respmodels.AnalysisListResponse, False),
+        (testdata.DETECTED_ISSUES_RESPONSE_DICT, respmodels.DetectedIssuesResponse, False),
+        (testdata.ANALYSIS_STATUS_RESPONSE_DICT, respmodels.AnalysisStatusResponse, False),
+        (testdata.ANALYSIS_SUBMISSION_RESPONSE_DICT, respmodels.AnalysisSubmissionResponse, False),
+        (testdata.LOGIN_RESPONSE_DICT, respmodels.AuthLoginResponse, False),
+        (testdata.LOGOUT_RESPONSE_DICT, respmodels.AuthLogoutResponse, True),
+        (testdata.REFRESH_RESPONSE_DICT, respmodels.AuthRefreshResponse, False),
+    ],
+)
+def test_model_validators(r_dict, model, should_raise):
+    if should_raise:
+        with pytest.raises(TypeError):
+            model.validate(r_dict)
+    else:
+        model.validate(r_dict)

--- a/tests/test_oas_request.py
+++ b/tests/test_oas_request.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from . import common as testdata
-from pythx.models.exceptions import RequestDecodeError
+from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import OASRequest
 
 
@@ -29,7 +29,7 @@ def test_oas_request_from_valid_dict():
 
 
 def test_invalid_format():
-    with pytest.raises(RequestDecodeError):
+    with pytest.raises(RequestValidationError):
         OASRequest(mode="invalid")
 
 

--- a/tests/test_oas_request.py
+++ b/tests/test_oas_request.py
@@ -2,9 +2,10 @@ import json
 
 import pytest
 
-from . import common as testdata
 from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import OASRequest
+
+from . import common as testdata
 
 
 def assert_version_request(req):

--- a/tests/test_oas_request.py
+++ b/tests/test_oas_request.py
@@ -39,7 +39,3 @@ def test_oas_request_to_json():
 
 def test_oas_request_to_dict():
     assert testdata.OPENAPI_REQUEST_OBJECT.to_dict() == {}
-
-
-def test_validate():
-    testdata.OPENAPI_REQUEST_OBJECT.validate()

--- a/tests/test_oas_response.py
+++ b/tests/test_oas_response.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from . import common as testdata
-from pythx.models.exceptions import ResponseDecodeError
+from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import OASResponse
 
 
@@ -18,7 +18,7 @@ def test_oas_response_from_valid_dict():
 
 
 def test_oas_response_from_invalid_dict():
-    with pytest.raises(ResponseDecodeError):
+    with pytest.raises(ResponseValidationError):
         OASResponse.from_dict({})
 
 
@@ -37,7 +37,3 @@ def test_oas_response_to_dict():
     assert testdata.OPENAPI_RESPONSE_OBJECT.to_dict() == {
         "data": testdata.OPENAPI_RESPONSE
     }
-
-
-def test_validate():
-    testdata.OPENAPI_RESPONSE_OBJECT.validate()

--- a/tests/test_oas_response.py
+++ b/tests/test_oas_response.py
@@ -2,9 +2,10 @@ import json
 
 import pytest
 
-from . import common as testdata
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import OASResponse
+
+from . import common as testdata
 
 
 def test_oas_response_from_valid_json():

--- a/tests/test_version_request.py
+++ b/tests/test_version_request.py
@@ -3,7 +3,6 @@ import json
 import pytest
 
 from . import common as testdata
-from pythx.models.exceptions import RequestDecodeError
 from pythx.models.request import VersionRequest
 
 

--- a/tests/test_version_request.py
+++ b/tests/test_version_request.py
@@ -31,7 +31,3 @@ def test_auth_logout_request_to_json():
 
 def test_auth_logout_request_to_dict():
     assert testdata.VERSION_REQUEST_OBJECT.to_dict() == {}
-
-
-def test_validate():
-    testdata.VERSION_REQUEST_OBJECT.validate()

--- a/tests/test_version_request.py
+++ b/tests/test_version_request.py
@@ -2,8 +2,9 @@ import json
 
 import pytest
 
-from . import common as testdata
 from pythx.models.request import VersionRequest
+
+from . import common as testdata
 
 
 def assert_version_request(req):

--- a/tests/test_version_response.py
+++ b/tests/test_version_response.py
@@ -2,9 +2,10 @@ import json
 
 import pytest
 
-from . import common as testdata
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import VersionResponse
+
+from . import common as testdata
 
 
 def assert_version_response(resp: VersionResponse):

--- a/tests/test_version_response.py
+++ b/tests/test_version_response.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from . import common as testdata
-from pythx.models.exceptions import ResponseDecodeError
+from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import VersionResponse
 
 
@@ -27,12 +27,12 @@ def test_auth_logout_request_from_valid_dict():
 
 
 def test_auth_logout_request_from_invalid_dict():
-    with pytest.raises(ResponseDecodeError):
+    with pytest.raises(ResponseValidationError):
         VersionResponse.from_dict({})
 
 
 def test_auth_logout_request_from_invalid_json():
-    with pytest.raises(ResponseDecodeError):
+    with pytest.raises(ResponseValidationError):
         VersionResponse.from_json("{}")
 
 
@@ -45,7 +45,3 @@ def test_auth_logout_request_to_json():
 
 def test_auth_logout_request_to_dict():
     assert testdata.VERSION_RESPONSE_OBJECT.to_dict() == testdata.VERSION_RESPONSE_DICT
-
-
-def test_validate():
-    testdata.VERSION_RESPONSE_OBJECT.validate()


### PR DESCRIPTION
This PR will add:
- magic methods to the analysis list and detected issues response models
-  delegated property acces for easier access to a model's underlying Analysis object
- a context handler for the client class to allow easy usage with various accounts
- jsonschema validation for all requests and responses

Furthermore, the `*DecodeError` exceptions have been deprecated in favour of the `*ValidationError` ones. This makes it easier to catch internal PythX errors. As discussed before, an example like this is now possible:
```python
with Client(eth_address="0xF00...", password="my-password") as c:
    print(c.analysis_list())
```

Next up: Further UX improvements, examples in the readme, actual documentation, and then v1.0 :tada: 