### PR TITLE
Fix setup.py install and CLI circular import issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ ENV/
 .mypy_cache/
 *.swp
 .vscode/
+.idea/

--- a/pythx/__init__.py
+++ b/pythx/__init__.py
@@ -4,8 +4,7 @@ __author__ = """Dominik Muhs"""
 __email__ = "dominik.muhs@consensys.net"
 __version__ = "0.1.0"
 
-
-from pythx.config import config
+from pythx.conf import config
 from pythx.api.client import Client
 from pythx.models.exceptions import (
     PythXBaseException,

--- a/pythx/api/client.py
+++ b/pythx/api/client.py
@@ -1,11 +1,10 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Dict, List
 
 import jwt
 
 from pythx.api.handler import APIHandler
-from pythx.config import config
 from pythx.models import request as reqmodels
 from pythx.models import response as respmodels
 

--- a/pythx/api/handler.py
+++ b/pythx/api/handler.py
@@ -6,8 +6,6 @@ import requests
 
 from pythx import config
 from pythx.middleware.base import BaseMiddleware
-from pythx.models import request as reqmodels
-from pythx.models import response as respmodels
 from pythx.models.exceptions import PythXAPIError
 
 

--- a/pythx/cli/main.py
+++ b/pythx/cli/main.py
@@ -5,19 +5,16 @@ import os
 import sys
 import tempfile
 import time
-from os import environ, path
-from pprint import pprint
 from collections import defaultdict
-from distutils import spawn
-from subprocess import check_output
 from copy import copy
-import tempfile
+from distutils import spawn
+from os import environ, path
+from subprocess import check_output
 
 import click
 from tabulate import tabulate
 
 from pythx.api import Client
-
 
 if environ.get("PYTHX_DEBUG") is not None:
     logging.basicConfig(level=logging.DEBUG)

--- a/pythx/conf/__init__.py
+++ b/pythx/conf/__init__.py
@@ -1,0 +1,4 @@
+from pythx.conf.base import PythXConfig
+
+
+config = PythXConfig()

--- a/pythx/conf/base.py
+++ b/pythx/conf/base.py
@@ -1,6 +1,3 @@
-from pythx.models import request as reqmodels
-
-
 class PythXConfig(dict):
     def __init__(self):
         self["endpoints"] = {

--- a/pythx/config/__init__.py
+++ b/pythx/config/__init__.py
@@ -1,4 +1,0 @@
-from pythx.config.base import PythXConfig
-
-
-config = PythXConfig()

--- a/pythx/models/request/analysis_list.py
+++ b/pythx/models/request/analysis_list.py
@@ -1,12 +1,10 @@
-import json
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 import dateutil.parser
 
-from pythx.models.exceptions import RequestDecodeError, RequestValidationError
+from pythx.models.exceptions import RequestDecodeError
 from pythx.models.request.base import BaseRequest
-from pythx.models.util import dict_delete_none_fields
 
 ANALYSIS_LIST_KEYS = ("offset", "dateFrom", "dateTo")
 

--- a/pythx/models/request/analysis_status.py
+++ b/pythx/models/request/analysis_status.py
@@ -1,12 +1,5 @@
-import json
-from datetime import datetime
-from typing import Any, Dict, List
-
-import dateutil.parser
-
-from pythx.models.exceptions import RequestDecodeError, RequestValidationError
+from pythx.models.exceptions import RequestDecodeError
 from pythx.models.request.base import BaseRequest
-from pythx.models.util import dict_delete_none_fields
 
 
 class AnalysisStatusRequest(BaseRequest):

--- a/pythx/models/request/analysis_submission.py
+++ b/pythx/models/request/analysis_submission.py
@@ -1,9 +1,5 @@
-import json
 import logging
-from datetime import datetime
-from typing import Any, Dict, List
-
-import dateutil.parser
+from typing import Dict, List
 
 from pythx.models.exceptions import RequestDecodeError, RequestValidationError
 from pythx.models.request.base import BaseRequest

--- a/pythx/models/request/auth_login.py
+++ b/pythx/models/request/auth_login.py
@@ -1,12 +1,7 @@
-import json
-from datetime import datetime
-from typing import Any, Dict, List
+from typing import Dict
 
-import dateutil.parser
-
-from pythx.models.exceptions import RequestDecodeError, RequestValidationError
+from pythx.models.exceptions import RequestDecodeError
 from pythx.models.request.base import BaseRequest
-from pythx.models.util import dict_delete_none_fields
 
 AUTH_LOGIN_KEYS = ("ethAddress", "password")
 

--- a/pythx/models/request/auth_logout.py
+++ b/pythx/models/request/auth_logout.py
@@ -1,12 +1,7 @@
-import json
-from datetime import datetime
-from typing import Any, Dict, List
+from typing import Dict
 
-import dateutil.parser
-
-from pythx.models.exceptions import RequestDecodeError, RequestValidationError
+from pythx.models.exceptions import RequestDecodeError
 from pythx.models.request.base import BaseRequest
-from pythx.models.util import dict_delete_none_fields
 
 
 class AuthLogoutRequest(BaseRequest):

--- a/pythx/models/request/auth_refresh.py
+++ b/pythx/models/request/auth_refresh.py
@@ -1,12 +1,7 @@
-import json
-from datetime import datetime
-from typing import Any, Dict, List
+from typing import Dict
 
-import dateutil.parser
-
-from pythx.models.exceptions import RequestDecodeError, RequestValidationError
+from pythx.models.exceptions import RequestDecodeError
 from pythx.models.request.base import BaseRequest
-from pythx.models.util import dict_delete_none_fields
 
 AUTH_REFRESH_KEYS = ("access", "refresh")
 

--- a/pythx/models/request/detected_issues.py
+++ b/pythx/models/request/detected_issues.py
@@ -1,12 +1,4 @@
-import json
-from datetime import datetime
-from typing import Any, Dict, List
-
-import dateutil.parser
-
-from pythx.models.exceptions import RequestDecodeError, RequestValidationError
 from pythx.models.request.analysis_status import AnalysisStatusRequest
-from pythx.models.util import dict_delete_none_fields
 
 
 class DetectedIssuesRequest(AnalysisStatusRequest):

--- a/pythx/models/request/oas.py
+++ b/pythx/models/request/oas.py
@@ -1,13 +1,5 @@
-import json
-from datetime import datetime
-from typing import Any, Dict, List
-
-import dateutil.parser
-
-from pythx.models.exceptions import RequestDecodeError, RequestValidationError
-from pythx.models.request.analysis_status import AnalysisStatusRequest
+from pythx.models.exceptions import RequestDecodeError
 from pythx.models.request.base import BaseRequest
-from pythx.models.util import dict_delete_none_fields
 
 
 class OASRequest(BaseRequest):

--- a/pythx/models/request/version.py
+++ b/pythx/models/request/version.py
@@ -1,13 +1,4 @@
-import json
-from datetime import datetime
-from typing import Any, Dict, List
-
-import dateutil.parser
-
-from pythx.models.exceptions import RequestDecodeError, RequestValidationError
-from pythx.models.request.analysis_status import AnalysisStatusRequest
 from pythx.models.request.base import BaseRequest
-from pythx.models.util import dict_delete_none_fields
 
 
 class VersionRequest(BaseRequest):

--- a/pythx/models/response/analysis.py
+++ b/pythx/models/response/analysis.py
@@ -1,7 +1,5 @@
-import json
 from enum import Enum
 
-import dateutil.parser
 from inflection import underscore
 
 from pythx.models.exceptions import ResponseDecodeError

--- a/pythx/models/response/analysis_list.py
+++ b/pythx/models/response/analysis_list.py
@@ -1,10 +1,8 @@
-import json
-from typing import Any, Dict, List
+from typing import List
 
 from pythx.models.exceptions import ResponseDecodeError, ResponseValidationError
 from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
-from pythx.models.response.issue import Issue, SourceFormat, SourceType
 
 ANALYSIS_LIST_KEYS = ["analyses", "total"]
 

--- a/pythx/models/response/analysis_submission.py
+++ b/pythx/models/response/analysis_submission.py
@@ -1,10 +1,5 @@
-import json
-from typing import Any, Dict, List
-
-from pythx.models.exceptions import ResponseDecodeError
 from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
-from pythx.models.response.issue import Issue, SourceFormat, SourceType
 
 
 class AnalysisSubmissionResponse(BaseResponse):

--- a/pythx/models/response/auth_login.py
+++ b/pythx/models/response/auth_login.py
@@ -1,10 +1,7 @@
-import json
-from typing import Any, Dict, List
+from typing import Dict
 
 from pythx.models.exceptions import ResponseDecodeError
-from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
-from pythx.models.response.issue import Issue, SourceFormat, SourceType
 
 AUTH_LOGIN_KEYS = ("access", "refresh")
 

--- a/pythx/models/response/auth_logout.py
+++ b/pythx/models/response/auth_logout.py
@@ -1,10 +1,7 @@
-import json
-from typing import Any, Dict, List
+from typing import Dict
 
 from pythx.models.exceptions import ResponseDecodeError
-from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
-from pythx.models.response.issue import Issue, SourceFormat, SourceType
 
 
 class AuthLogoutResponse(BaseResponse):

--- a/pythx/models/response/auth_refresh.py
+++ b/pythx/models/response/auth_refresh.py
@@ -1,10 +1,7 @@
-import json
-from typing import Any, Dict, List
+from typing import Dict
 
 from pythx.models.exceptions import ResponseDecodeError
-from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
-from pythx.models.response.issue import Issue, SourceFormat, SourceType
 
 AUTH_LOGIN_KEYS = ("access", "refresh")
 

--- a/pythx/models/response/detected_issues.py
+++ b/pythx/models/response/detected_issues.py
@@ -1,8 +1,6 @@
-import json
 from typing import Any, Dict, List
 
 from pythx.models.exceptions import ResponseDecodeError
-from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
 from pythx.models.response.issue import Issue, SourceFormat, SourceType
 

--- a/pythx/models/response/issue.py
+++ b/pythx/models/response/issue.py
@@ -1,8 +1,6 @@
 import json
 from enum import Enum
-from typing import Any, Dict, List, Tuple
-
-from inflection import underscore
+from typing import Any, Dict, List
 
 from pythx.models.exceptions import ResponseDecodeError
 

--- a/pythx/models/response/oas.py
+++ b/pythx/models/response/oas.py
@@ -1,10 +1,7 @@
-import json
-from typing import Any, Dict, List
+from typing import Dict
 
 from pythx.models.exceptions import ResponseDecodeError
-from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
-from pythx.models.response.issue import Issue, SourceFormat, SourceType
 
 
 class OASResponse(BaseResponse):

--- a/pythx/models/response/version.py
+++ b/pythx/models/response/version.py
@@ -1,10 +1,7 @@
-import json
-from typing import Any, Dict, List
+from typing import Dict
 
 from pythx.models.exceptions import ResponseDecodeError
-from pythx.models.response.analysis import Analysis
 from pythx.models.response.base import BaseResponse
-from pythx.models.response.issue import Issue, SourceFormat, SourceType
 
 VERSION_KEYS = ("api", "harvey", "mythril", "maestro", "maru", "hash")
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     include_package_data=True,
     keywords="pythx",
     name="pythx",
-    packages=find_packages(include=["pythx"]),
+    packages=find_packages(),
     setup_requires=setup_requirements,
     test_suite="tests",
     tests_require=test_requirements,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pythx import config
-from pythx.config.base import PythXConfig
+from pythx.conf.base import PythXConfig
 
 TEST_KEY = "test_key"
 TEST_VALUE = ("test_method", "test_value")


### PR DESCRIPTION
This PR fixes #3. The issue was caused due to a too strict limitation in what package we install (everything inside `pythx/` but not the directory itself), which resulted in an import error. Furthermore, there was a circular import issue on top of that based on different modules using `pythx.config`. These were mostly stale imports, so I took the chance to remove them. To *really* make sure we don't run into more import issues, I also refactored `pythx.config` to `pythx.conf` to avoid name shadowing with the global config variable name.

This issue only occurred when running `python setup.py install`, but not with `pip install .`.