### PR TITLE
Add clientToolName middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ ENV/
 .mypy_cache/
 *.swp
 .vscode/
+.idea/

--- a/pythx/api/client.py
+++ b/pythx/api/client.py
@@ -6,6 +6,7 @@ import jwt
 
 from pythx.api.handler import APIHandler
 from pythx.config import config
+from pythx.middleware.toolname import ClientToolNameMiddleware
 from pythx.models import request as reqmodels
 from pythx.models import response as respmodels
 
@@ -24,7 +25,10 @@ class Client:
     ):
         self.eth_address = eth_address
         self.password = password
-        self.handler = handler or APIHandler(staging=staging)
+        self.handler = handler or APIHandler(
+            middlewares=[ClientToolNameMiddleware()],
+            staging=staging
+        )
 
         self.access_token = access_token
         self.refresh_token = refresh_token

--- a/pythx/middleware/base.py
+++ b/pythx/middleware/base.py
@@ -3,9 +3,9 @@ import abc
 
 class BaseMiddleware(abc.ABC):
     @abc.abstractmethod
-    def process_request(self):
+    def process_request(self, req):
         pass
 
     @abc.abstractmethod
-    def process_response(self):
+    def process_response(self, resp):
         pass

--- a/pythx/middleware/toolname.py
+++ b/pythx/middleware/toolname.py
@@ -1,0 +1,21 @@
+import logging
+from pythx.middleware.base import BaseMiddleware
+
+
+LOGGER = logging.getLogger("ClientToolNameMiddleware")
+
+
+class ClientToolNameMiddleware(BaseMiddleware):
+    def __init__(self, name="pythx"):
+        LOGGER.debug("Initializing")
+        self.name = name
+
+    def process_request(self, req):
+        if req["method"] == "POST" and req["url"].endswith("/analyses"):
+            LOGGER.debug("Adding name %s to request", self.name)
+            req["payload"]["clientToolName"] = self.name
+        return req
+
+    def process_response(self, resp):
+        LOGGER.debug("Forwarding the response without any action")
+        return resp

--- a/tests/test_client_tool_name_middleware.py
+++ b/tests/test_client_tool_name_middleware.py
@@ -1,0 +1,71 @@
+import pytest
+
+from . import common as testdata
+from pythx.middleware.toolname import ClientToolNameMiddleware
+
+
+DEFAULT_CTN_MIDDLEWARE = ClientToolNameMiddleware()
+CUSTOM_CTN_MIDDLEWARE = ClientToolNameMiddleware(name="test")
+
+
+def generate_request_dict(req):
+    return {
+        "method": req.method,
+        "payload": req.payload,
+        "params": req.parameters,
+        "headers": req.headers,
+        "url": "https://test.com/" + req.endpoint,
+    }
+
+
+@pytest.mark.parametrize(
+    "middleware,request_dict,name_added",
+    [
+        (DEFAULT_CTN_MIDDLEWARE, generate_request_dict(testdata.ANALYSIS_LIST_REQUEST_OBJECT), False),
+        (DEFAULT_CTN_MIDDLEWARE, generate_request_dict(testdata.DETECTED_ISSUES_REQUEST_OBJECT), False),
+        (DEFAULT_CTN_MIDDLEWARE, generate_request_dict(testdata.ANALYSIS_STATUS_REQUEST_OBJECT), False),
+        (DEFAULT_CTN_MIDDLEWARE, generate_request_dict(testdata.ANALYSIS_SUBMISSION_REQUEST_OBJECT), True),
+        (DEFAULT_CTN_MIDDLEWARE, generate_request_dict(testdata.LOGIN_REQUEST_OBJECT), False),
+        (DEFAULT_CTN_MIDDLEWARE, generate_request_dict(testdata.LOGOUT_REQUEST_OBJECT), False),
+        (DEFAULT_CTN_MIDDLEWARE, generate_request_dict(testdata.REFRESH_REQUEST_OBJECT), False),
+        (CUSTOM_CTN_MIDDLEWARE, generate_request_dict(testdata.ANALYSIS_LIST_REQUEST_OBJECT), False),
+        (CUSTOM_CTN_MIDDLEWARE, generate_request_dict(testdata.DETECTED_ISSUES_REQUEST_OBJECT), False),
+        (CUSTOM_CTN_MIDDLEWARE, generate_request_dict(testdata.ANALYSIS_STATUS_REQUEST_OBJECT), False),
+        (CUSTOM_CTN_MIDDLEWARE, generate_request_dict(testdata.ANALYSIS_SUBMISSION_REQUEST_OBJECT), True),
+        (CUSTOM_CTN_MIDDLEWARE, generate_request_dict(testdata.LOGIN_REQUEST_OBJECT), False),
+        (CUSTOM_CTN_MIDDLEWARE, generate_request_dict(testdata.LOGOUT_REQUEST_OBJECT), False),
+        (CUSTOM_CTN_MIDDLEWARE, generate_request_dict(testdata.REFRESH_REQUEST_OBJECT), False),
+    ],
+)
+def test_request_dicts(middleware, request_dict, name_added):
+    new_request = middleware.process_request(request_dict)
+    if name_added:
+        assert new_request["payload"].get("clientToolName") == middleware.name
+        del new_request["payload"]["clientToolName"]
+
+    # rest of the result should stay the same
+    assert request_dict == new_request
+
+
+@pytest.mark.parametrize(
+    "middleware,resp_obj",
+    [
+        (DEFAULT_CTN_MIDDLEWARE, testdata.ANALYSIS_LIST_RESPONSE_OBJECT),
+        (DEFAULT_CTN_MIDDLEWARE, testdata.DETECTED_ISSUES_RESPONSE_OBJECT),
+        (DEFAULT_CTN_MIDDLEWARE, testdata.ANALYSIS_STATUS_RESPONSE_OBJECT),
+        (DEFAULT_CTN_MIDDLEWARE, testdata.ANALYSIS_SUBMISSION_RESPONSE_OBJECT),
+        (DEFAULT_CTN_MIDDLEWARE, testdata.LOGIN_RESPONSE_OBJECT),
+        (DEFAULT_CTN_MIDDLEWARE, testdata.LOGOUT_RESPONSE_OBJECT),
+        (DEFAULT_CTN_MIDDLEWARE, testdata.REFRESH_RESPONSE_OBJECT),
+        (CUSTOM_CTN_MIDDLEWARE, testdata.ANALYSIS_LIST_RESPONSE_OBJECT),
+        (CUSTOM_CTN_MIDDLEWARE, testdata.DETECTED_ISSUES_RESPONSE_OBJECT),
+        (CUSTOM_CTN_MIDDLEWARE, testdata.ANALYSIS_STATUS_RESPONSE_OBJECT),
+        (CUSTOM_CTN_MIDDLEWARE, testdata.ANALYSIS_SUBMISSION_RESPONSE_OBJECT),
+        (CUSTOM_CTN_MIDDLEWARE, testdata.LOGIN_RESPONSE_OBJECT),
+        (CUSTOM_CTN_MIDDLEWARE, testdata.LOGOUT_RESPONSE_OBJECT),
+        (CUSTOM_CTN_MIDDLEWARE, testdata.REFRESH_RESPONSE_OBJECT),
+    ],
+)
+def test_response_models(middleware, resp_obj):
+    new_resp_obj = middleware.process_response(resp_obj)
+    assert new_resp_obj == resp_obj


### PR DESCRIPTION
Add a middleware that automatically fills in the `clientToolName` field of analysis submission requests so people on the API side know PythX was used. 