### PR TITLE
Add truffle support for CLI

### DIFF
--- a/pythx/api/client.py
+++ b/pythx/api/client.py
@@ -5,6 +5,7 @@ from typing import Dict, List
 import jwt
 from pythx.api.handler import APIHandler
 from pythx.middleware.toolname import ClientToolNameMiddleware
+from pythx.middleware.analysiscache import AnalysisCacheMiddleware
 from pythx.models import request as reqmodels
 from pythx.models import response as respmodels
 
@@ -33,11 +34,12 @@ class Client:
         refresh_token: str = None,
         handler: APIHandler = None,
         staging: bool = False,
+        no_cache: bool = False,
     ):
         self.eth_address = eth_address
         self.password = password
         self.handler = handler or APIHandler(
-            middlewares=[ClientToolNameMiddleware()], staging=staging
+            middlewares=[ClientToolNameMiddleware(), AnalysisCacheMiddleware(no_cache)], staging=staging
         )
 
         self.access_token = access_token

--- a/pythx/api/client.py
+++ b/pythx/api/client.py
@@ -4,8 +4,8 @@ from typing import Dict, List
 
 import jwt
 from pythx.api.handler import APIHandler
-from pythx.middleware.toolname import ClientToolNameMiddleware
 from pythx.middleware.analysiscache import AnalysisCacheMiddleware
+from pythx.middleware.toolname import ClientToolNameMiddleware
 from pythx.models import request as reqmodels
 from pythx.models import response as respmodels
 
@@ -39,7 +39,8 @@ class Client:
         self.eth_address = eth_address
         self.password = password
         self.handler = handler or APIHandler(
-            middlewares=[ClientToolNameMiddleware(), AnalysisCacheMiddleware(no_cache)], staging=staging
+            middlewares=[ClientToolNameMiddleware(), AnalysisCacheMiddleware(no_cache)],
+            staging=staging,
         )
 
         self.access_token = access_token

--- a/pythx/api/client.py
+++ b/pythx/api/client.py
@@ -54,7 +54,7 @@ class Client:
         auth_header = (
             {"Authorization": "Bearer {}".format(self.access_token)}
             if include_auth_header
-            else {}
+            else None
         )
         req_dict = self.handler.assemble_request(req_obj)
         LOGGER.debug("Sending request")
@@ -96,7 +96,7 @@ class Client:
                     access_expiration, now, refresh_expiration
                 )
             )
-            self.refresh(assert_authentication=False)
+            self.refresh()
         else:
             # refresh token has also expired - let's login again
             LOGGER.debug("Access and refresh token have expired - logging in again")
@@ -131,10 +131,9 @@ class Client:
         self.refresh_token = None
         return resp_model
 
-    def refresh(self, assert_authentication=True) -> respmodels.AuthRefreshResponse:
+    def refresh(self) -> respmodels.AuthRefreshResponse:
         """Perform a JWT refresh on the API and return the response.
 
-        :param assert_authentication:
         :return: AuthRefreshResponse
         """
         req = reqmodels.AuthRefreshRequest(

--- a/pythx/api/client.py
+++ b/pythx/api/client.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from typing import Dict, List
 
 import jwt
-
 from pythx.api.handler import APIHandler
 from pythx.middleware.toolname import ClientToolNameMiddleware
 from pythx.models import request as reqmodels

--- a/pythx/api/handler.py
+++ b/pythx/api/handler.py
@@ -3,7 +3,6 @@ import urllib.parse
 from typing import Dict, List
 
 import requests
-
 from pythx import config
 from pythx.middleware.base import BaseMiddleware
 from pythx.models.exceptions import PythXAPIError

--- a/pythx/api/handler.py
+++ b/pythx/api/handler.py
@@ -66,7 +66,7 @@ class APIHandler:
 
             {
                 "method": "GET",
-                "headers": {}
+                "headers": {},
                 "url": "https://api.mythx.io/v1/analyses/6b9e4a52-f061-4960-8246-e1560627336a/issues",
                 "payload": "",
                 "params": {}

--- a/pythx/cli/logger.py
+++ b/pythx/cli/logger.py
@@ -1,3 +1,5 @@
+"""This module contains the CLI logger."""
+
 import logging
 from os import environ
 

--- a/pythx/cli/logger.py
+++ b/pythx/cli/logger.py
@@ -1,0 +1,9 @@
+import logging
+from os import environ
+
+if environ.get("PYTHX_DEBUG") is not None:
+    logging.basicConfig(level=logging.DEBUG)
+else:
+    logging.basicConfig(level=logging.ERROR)
+
+LOGGER = logging.getLogger("pythx-cli")

--- a/pythx/cli/main.py
+++ b/pythx/cli/main.py
@@ -255,6 +255,7 @@ def truffle(config, staging, no_cache):
     c = utils.recover_client(config_path=config, staging=staging, no_cache=no_cache)
 
     jobs = []
+    job_to_name = {}
     for artifact_file in find_artifacts(os.getcwd()):
         LOGGER.debug("Processing %s", artifact_file)
         with open(artifact_file) as af:
@@ -282,17 +283,19 @@ def truffle(config, staging, no_cache):
             solc_version=artifact["compiler"]["version"]
         )
         jobs.append(resp.uuid)
-        click.echo("Submitted contract {} as job {}".format(contract_name, resp.uuid))
+        job_to_name[resp.uuid] = contract_name
+        click.echo("Submitted: {} ({})".format(resp.uuid, contract_name))
 
     for uuid in jobs:
-        click.echo("Waiting for job {} to finish".format(uuid))
+        click.echo("Waiting: {} ({})".format(uuid, job_to_name[uuid]))
         while not c.analysis_ready(uuid):
             time.sleep(3)
-        click.echo("Analysis {} done".format(uuid))
+        click.echo("Done: {} ({})".format(uuid, job_to_name[uuid]))
 
     for uuid in jobs:
         # print the results
         utils.echo_report_as_table(c.report(uuid))
+        click.echo()
         time.sleep(3)
 
     utils.update_config(config_path=config, client=c)

--- a/pythx/cli/main.py
+++ b/pythx/cli/main.py
@@ -5,19 +5,18 @@ library around the MythX smart contract security analysis API.
 """
 import json
 import os
-from os import path
 import sys
 import time
-from collections import defaultdict
 from copy import copy
-from typing import List
+from os import path
 
 import click
+from tabulate import tabulate
+
 from pythx.api import Client
 from pythx.cli import opts, utils
 from pythx.cli.logger import LOGGER
 from pythx.cli.truffle import find_artifacts
-from tabulate import tabulate
 
 
 @click.group()

--- a/pythx/cli/main.py
+++ b/pythx/cli/main.py
@@ -19,6 +19,8 @@ import click
 from tabulate import tabulate
 
 from pythx.api import Client
+from pythx.cli import opts
+
 
 if environ.get("PYTHX_DEBUG") is not None:
     logging.basicConfig(level=logging.DEBUG)
@@ -26,58 +28,8 @@ else:
     logging.basicConfig(level=logging.ERROR)
 
 LOGGER = logging.getLogger("pythx-cli")
-DEFAULT_STORAGE_PATH = path.join(tempfile.gettempdir(), ".pythx.json")
-CONFIG_KEYS = ("access", "refresh", "username", "password")
 
-staging_opt = click.option(
-    "--staging",
-    default=False,
-    is_flag=True,
-    envvar="PYTHX_STAGING",
-    help="Use the MythX staging environment",
-)
-config_opt = click.option(
-    "--config",
-    default=DEFAULT_STORAGE_PATH,
-    envvar="PYTHX_CONFIG",
-    help="Path to user credentials JSON file",
-)
-html_opt = click.option(
-    "--html", "mode", flag_value="html", help="Get the HTML OpenAPI spec"
-)
-yaml_opt = click.option(
-    "--yaml", "mode", flag_value="yaml", default=True, help="Get the YAML OpenAPI spec"
-)
-number_opt = click.option(
-    "--number",
-    default=20,
-    type=click.IntRange(min=1, max=100),
-    help="The number of most recent analysis jobs to display",
-)
-bytecode_file_opt = click.option(
-    "--bytecode-file",
-    "-bf",
-    type=click.Path(exists=True),
-    default=None,
-    help="Path to file containing creation bytecode",
-)
-source_file_opt = click.option(
-    "--source-file",
-    "-sf",
-    type=click.Path(exists=True),
-    default=None,
-    help="Path to file containing Solidity source code",
-)
-interval_opt = click.option(
-    "--interval", default=5, type=click.INT, help="Refresh interval"
-)
-solc_path_opt = click.option(
-    "--solc-path",
-    type=click.Path(exists=True),
-    default=None,
-    help="Path to the solc compiler",
-)
-uuid_arg = click.argument("uuid", type=click.UUID)
+CONFIG_KEYS = ("access", "refresh", "username", "password")
 
 
 def parse_config(config_path, tokens_required=False):
@@ -248,8 +200,8 @@ def cli():
 
 
 @cli.command(help="Login to your MythX account")
-@staging_opt
-@config_opt
+@opts.staging_opt
+@opts.config_opt
 def login(staging, config):
     """Perform a login action on the API
 
@@ -268,8 +220,8 @@ def login(staging, config):
 
 
 @cli.command(help="Log out of your MythX account")
-@config_opt
-@staging_opt
+@opts.config_opt
+@opts.staging_opt
 def logout(config, staging):
     """Perform a logout action on the API.
 
@@ -287,8 +239,8 @@ def logout(config, staging):
 
 
 @cli.command(help="Refresh your MythX API token")
-@staging_opt
-@config_opt
+@opts.staging_opt
+@opts.config_opt
 def refresh(staging, config):
     """Perform a refresh action on the API.
 
@@ -307,9 +259,9 @@ def refresh(staging, config):
 
 
 @cli.command(help="Get the OpenAPI spec in HTML or YAML format")
-@staging_opt
-@html_opt
-@yaml_opt
+@opts.staging_opt
+@opts.html_opt
+@opts.yaml_opt
 def openapi(staging, mode):
     """Return the API's OpenAPI spec data in HTML or YAML format.
 
@@ -321,7 +273,7 @@ def openapi(staging, mode):
 
 
 @cli.command(help="Print version information of PythX and the API")
-@staging_opt
+@opts.staging_opt
 def version(staging):
     """Return the API's version information as a pretty table.
 
@@ -334,9 +286,9 @@ def version(staging):
 
 
 @cli.command(help="Get the status of an analysis by its UUID")
-@config_opt
-@staging_opt
-@uuid_arg
+@opts.config_opt
+@opts.staging_opt
+@opts.uuid_arg
 def status(config, staging, uuid):
     """Return the status of an analysis job as a pretty table.
 
@@ -352,9 +304,9 @@ def status(config, staging, uuid):
 
 
 @cli.command(help="Get a greppable overview of submitted analyses")
-@config_opt
-@staging_opt
-@number_opt
+@opts.config_opt
+@opts.staging_opt
+@opts.number_opt
 def ps(config, staging, number):
     """Return a list of the most recent analyses as a pretty table and exit.
 
@@ -368,9 +320,9 @@ def ps(config, staging, number):
 
 
 @cli.command(help="Display the most recent analysis jobs and their status")
-@config_opt
-@staging_opt
-@interval_opt
+@opts.config_opt
+@opts.staging_opt
+@opts.interval_opt
 def top(config, staging, interval):
     """Return a list of the most recent analyses as a pretty table and update it continuously.
 
@@ -387,11 +339,11 @@ def top(config, staging, interval):
 
 
 @cli.command(help="Submit a new analysis job based on source code, byte code, or both")
-@config_opt
-@staging_opt
-@bytecode_file_opt
-@source_file_opt
-@solc_path_opt
+@opts.config_opt
+@opts.staging_opt
+@opts.bytecode_file_opt
+@opts.source_file_opt
+@opts.solc_path_opt
 def check(config, staging, bytecode_file, source_file, solc_path):
     """
 
@@ -444,9 +396,9 @@ def check(config, staging, bytecode_file, source_file, solc_path):
 
 
 @cli.command(help="Check the detected issues of a finished analysis job")
-@config_opt
-@staging_opt
-@uuid_arg
+@opts.config_opt
+@opts.staging_opt
+@opts.uuid_arg
 def report(config, staging, uuid):
     """Retrieve the issue report and resolve the source maps to their file locations.
 

--- a/pythx/cli/main.py
+++ b/pythx/cli/main.py
@@ -256,7 +256,7 @@ def truffle(config, staging, no_cache):
 
     jobs = []
     for artifact_file in find_artifacts(os.getcwd()):
-        LOGGER.debug(f"Processing {artifact_file}")
+        LOGGER.debug("Processing %s", artifact_file)
         with open(artifact_file) as af:
             artifact = json.load(af)
 
@@ -282,13 +282,13 @@ def truffle(config, staging, no_cache):
             solc_version=artifact["compiler"]["version"]
         )
         jobs.append(resp.uuid)
-        click.echo(f"Submitted contract {contract_name} as job {resp.uuid}")
+        click.echo("Submitted contract {} as job {}".format(contract_name, resp.uuid))
 
     for uuid in jobs:
-        click.echo(f"Waiting for job {uuid} to finish")
+        click.echo("Waiting for job {} to finish".format(uuid))
         while not c.analysis_ready(uuid):
             time.sleep(3)
-        click.echo(f"Analysis {uuid} done")
+        click.echo("Analysis {} done".format(uuid))
 
     for uuid in jobs:
         # print the results

--- a/pythx/cli/main.py
+++ b/pythx/cli/main.py
@@ -11,12 +11,11 @@ from copy import copy
 from os import path
 
 import click
-from tabulate import tabulate
-
 from pythx.api import Client
 from pythx.cli import opts, utils
 from pythx.cli.logger import LOGGER
 from pythx.cli.truffle import find_artifacts
+from tabulate import tabulate
 
 
 @click.group()
@@ -275,16 +274,18 @@ def truffle(config, staging, no_cache):
             bytecode=bytecode if bytecode != "0x" else None,
             deployed_bytecode=deployed_bytecode if deployed_bytecode != "0x" else None,
             source_map=utils.zero_srcmap_indices(source_map) if source_map else None,
-            deployed_source_map=utils.zero_srcmap_indices(deyployed_source_map) if deyployed_source_map else None,
+            deployed_source_map=utils.zero_srcmap_indices(deyployed_source_map)
+            if deyployed_source_map
+            else None,
             sources={
                 path.basename(artifact.get("sourcePath")): {
                     "source": artifact.get("source"),
                     "ast": artifact.get("ast"),
-                    "legacyAST": artifact.get("legacyAST")
+                    "legacyAST": artifact.get("legacyAST"),
                 }
             },
             source_list=[artifact.get("sourcePath")],
-            solc_version=artifact["compiler"]["version"]
+            solc_version=artifact["compiler"]["version"],
         )
         jobs.append(resp.uuid)
         job_to_name[resp.uuid] = contract_name

--- a/pythx/cli/main.py
+++ b/pythx/cli/main.py
@@ -256,7 +256,11 @@ def truffle(config, staging, no_cache):
 
     jobs = []
     job_to_name = {}
-    for artifact_file in find_artifacts(os.getcwd()):
+    artifact_files = find_artifacts(os.getcwd())
+    if artifact_files is None:
+        click.echo("Could not find any artifact files. Did you run truffle compile?")
+        sys.exit(1)
+    for artifact_file in artifact_files:
         LOGGER.debug("Processing %s", artifact_file)
         with open(artifact_file) as af:
             artifact = json.load(af)

--- a/pythx/cli/main.py
+++ b/pythx/cli/main.py
@@ -3,17 +3,11 @@
 This script aims to be an example of how PythX can be used as a developer-friendly
 library around the MythX smart contract security analysis API.
 """
-import json
-import logging
 import os
 import sys
-import tempfile
 import time
 from collections import defaultdict
 from copy import copy
-from distutils import spawn
-from os import environ, path
-from subprocess import check_output
 
 import click
 from pythx.api import Client
@@ -97,7 +91,7 @@ def openapi(staging, mode):
     :param staging: Boolean whether to use the MythX staging deployment
     :param mode: The format to return the OpenAPI spec in (HTML or YAML)
     """
-    c = Client()  # no auth required
+    c = Client(staging=staging)  # no auth required
     click.echo(c.openapi(mode).data)
 
 

--- a/pythx/cli/main.py
+++ b/pythx/cli/main.py
@@ -167,7 +167,8 @@ def top(config, staging, interval):
 @opts.bytecode_file_opt
 @opts.source_file_opt
 @opts.solc_path_opt
-def check(config, staging, bytecode_file, source_file, solc_path):
+@opts.no_cache_opt
+def check(config, staging, bytecode_file, source_file, solc_path, no_cache):
     """Submit a new analysis job based on source code, byte code, or both.
 
     :param config: The configuration file's path
@@ -209,6 +210,7 @@ def check(config, staging, bytecode_file, source_file, solc_path):
             source_list=compiled["sourceList"],
             sources=sources_dict,
             solc_version=compiled["version"],
+            no_cache=no_cache,
         )
     else:
         click.echo("Please pass a bytecode or a source code file")

--- a/pythx/cli/main.py
+++ b/pythx/cli/main.py
@@ -270,8 +270,8 @@ def truffle(config, staging, no_cache):
             contract_name=contract_name,
             bytecode=bytecode if bytecode != "0x" else None,
             deployed_bytecode=deployed_bytecode if deployed_bytecode != "0x" else None,
-            source_map=zero_srcmap_indices(source_map) if source_map else None,
-            deployed_source_map=zero_srcmap_indices(deyployed_source_map) if deyployed_source_map else None,
+            source_map=utils.zero_srcmap_indices(source_map) if source_map else None,
+            deployed_source_map=utils.zero_srcmap_indices(deyployed_source_map) if deyployed_source_map else None,
             sources={
                 path.basename(artifact.get("sourcePath")): {
                     "source": artifact.get("source"),
@@ -293,23 +293,7 @@ def truffle(config, staging, no_cache):
 
     for uuid in jobs:
         # print the results
-        click.echo(c.status(uuid).to_dict())
-        # utils.echo_report_as_table(c.report(uuid))
+        utils.echo_report_as_table(c.report(uuid))
         time.sleep(3)
 
     utils.update_config(config_path=config, client=c)
-
-def execute_after(n, f, *args, **kwargs):
-    time.sleep(n)
-    return f(*args, **kwargs)
-
-def zero_srcmap_indices(src_map):
-    entries = src_map.split(";")
-    new_entries = copy(entries)
-    for i, entry in enumerate(entries):
-        fields = entry.split(":")
-        if len(fields) > 2 and fields[2] not in ("-1", ""):
-            # file index is in entry, needs fixing
-            fields[2] = "0"
-            new_entries[i] = ":".join(fields)
-    return ";".join(new_entries)

--- a/pythx/cli/main.py
+++ b/pythx/cli/main.py
@@ -175,6 +175,7 @@ def top(config, staging, interval):
 def check(config, staging, bytecode_file, source_file, solc_path, no_cache):
     """Submit a new analysis job based on source code, byte code, or both.
 
+    :param no_cache: Disable the API's result cache
     :param config: The configuration file's path
     :param staging: Boolean whether to use the MythX staging deployment
     :param bytecode_file: A file specifying the bytecode to analyse

--- a/pythx/cli/opts.py
+++ b/pythx/cli/opts.py
@@ -1,0 +1,57 @@
+import click
+from os import path
+import tempfile
+
+
+DEFAULT_STORAGE_PATH = path.join(tempfile.gettempdir(), ".pythx.json")
+
+
+staging_opt = click.option(
+    "--staging",
+    default=False,
+    is_flag=True,
+    envvar="PYTHX_STAGING",
+    help="Use the MythX staging environment",
+)
+config_opt = click.option(
+    "--config",
+    default=DEFAULT_STORAGE_PATH,
+    envvar="PYTHX_CONFIG",
+    help="Path to user credentials JSON file",
+)
+html_opt = click.option(
+    "--html", "mode", flag_value="html", help="Get the HTML OpenAPI spec"
+)
+yaml_opt = click.option(
+    "--yaml", "mode", flag_value="yaml", default=True, help="Get the YAML OpenAPI spec"
+)
+number_opt = click.option(
+    "--number",
+    default=20,
+    type=click.IntRange(min=1, max=100),
+    help="The number of most recent analysis jobs to display",
+)
+bytecode_file_opt = click.option(
+    "--bytecode-file",
+    "-bf",
+    type=click.Path(exists=True),
+    default=None,
+    help="Path to file containing creation bytecode",
+)
+source_file_opt = click.option(
+    "--source-file",
+    "-sf",
+    type=click.Path(exists=True),
+    default=None,
+    help="Path to file containing Solidity source code",
+)
+interval_opt = click.option(
+    "--interval", default=5, type=click.INT, help="Refresh interval"
+)
+solc_path_opt = click.option(
+    "--solc-path",
+    type=click.Path(exists=True),
+    default=None,
+    help="Path to the solc compiler",
+)
+uuid_arg = click.argument("uuid", type=click.UUID)

--- a/pythx/cli/opts.py
+++ b/pythx/cli/opts.py
@@ -1,7 +1,9 @@
-import click
-from os import path
-import tempfile
+"""This module contains the CLI option and argument decorators."""
 
+import tempfile
+from os import path
+
+import click
 
 DEFAULT_STORAGE_PATH = path.join(tempfile.gettempdir(), ".pythx.json")
 

--- a/pythx/cli/opts.py
+++ b/pythx/cli/opts.py
@@ -58,8 +58,5 @@ solc_path_opt = click.option(
 )
 uuid_arg = click.argument("uuid", type=click.UUID)
 no_cache_opt = click.option(
-    "--no-cache",
-    is_flag=True,
-    default=False,
-    help="Disable the API's request cache"
+    "--no-cache", is_flag=True, default=False, help="Disable the API's request cache"
 )

--- a/pythx/cli/opts.py
+++ b/pythx/cli/opts.py
@@ -59,7 +59,7 @@ solc_path_opt = click.option(
 uuid_arg = click.argument("uuid", type=click.UUID)
 no_cache_opt = click.option(
     "--no-cache",
-    type=bool,
+    is_flag=True,
     default=False,
     help="Disable the API's request cache"
 )

--- a/pythx/cli/opts.py
+++ b/pythx/cli/opts.py
@@ -57,3 +57,9 @@ solc_path_opt = click.option(
     help="Path to the solc compiler",
 )
 uuid_arg = click.argument("uuid", type=click.UUID)
+no_cache_opt = click.option(
+    "--no-cache",
+    type=bool,
+    default=False,
+    help="Disable the API's request cache"
+)

--- a/pythx/cli/truffle.py
+++ b/pythx/cli/truffle.py
@@ -1,0 +1,21 @@
+"""This module contains functions to submit Truffle projects to MythX."""
+
+from pythx.cli.logger import LOGGER
+from glob import glob
+from os import path
+
+
+def find_artifacts(project_dir):
+    """Look for a Truffle build folder and return all relevant JSON artifacts.
+
+    This function will skip the Migrations.json file and return all other paths
+    under .../build/contracts/.
+    """
+
+    output_pattern = path.join(project_dir, "build", "contracts", "*.json")
+    for json_file in glob(output_pattern):
+        if json_file.endswith("Migrations.json"):
+            LOGGER.debug("Skipping built migrations file")
+            continue
+
+        yield json_file

--- a/pythx/cli/truffle.py
+++ b/pythx/cli/truffle.py
@@ -1,6 +1,5 @@
 """This module contains functions to submit Truffle projects to MythX."""
 
-from pythx.cli.logger import LOGGER
 from glob import glob
 from os import path
 
@@ -9,13 +8,13 @@ def find_artifacts(project_dir):
     """Look for a Truffle build folder and return all relevant JSON artifacts.
 
     This function will skip the Migrations.json file and return all other paths
-    under .../build/contracts/.
+    under <project-dir>/build/contracts/.
     """
 
     output_pattern = path.join(project_dir, "build", "contracts", "*.json")
-    for json_file in glob(output_pattern):
-        if json_file.endswith("Migrations.json"):
-            LOGGER.debug("Skipping built migrations file")
-            continue
+    artifact_files = list(glob(output_pattern))
 
-        yield json_file
+    if not artifact_files:
+        return None
+
+    return [f for f in artifact_files if not f.endswith("Migrations.json")]

--- a/pythx/cli/utils.py
+++ b/pythx/cli/utils.py
@@ -142,19 +142,19 @@ def get_source_location_by_offset(filename, offset):
 
     :param filename: The Solidity file to analyze
     :param offset: The source map's offset
-    :return: The line and column number
+    :return: The line number
     """
     overall = 0
     line_ctr = 0
     if not path.exists(filename):
         LOGGER.warning("Could not find file %s", filename)
-        return 0, 0
+        return 0
     with open(filename) as f:
         for line in f:
             line_ctr += 1
             overall += len(line)
             if overall >= offset:
-                return line_ctr, overall - offset
+                return line_ctr
     LOGGER.error(
         "Error finding the source location in {} for offset {}".format(filename, offset)
     )
@@ -198,14 +198,14 @@ def echo_report_as_table(resp):
         for offset, _, file_idx in source_locs:
             if resp.source_list and file_idx >= 0:
                 filename = resp.source_list[file_idx]
-                line, column = get_source_location_by_offset(
+                line = get_source_location_by_offset(
                     filename, int(offset)
                 )
             else:
                 filename = "Unknown"
-                line, column = 0, 0
+                line = "Unknown"
             file_to_issue[filename].append(
-                (line, column, issue.swc_title, issue.severity, issue.description_short)
+                (line, issue.swc_title, issue.severity, issue.description_short)
             )
 
     for filename, data in file_to_issue.items():
@@ -216,7 +216,6 @@ def echo_report_as_table(resp):
                 tablefmt="fancy_grid",
                 headers=(
                     "Line",
-                    "Column",
                     "SWC Title",
                     "Severity",
                     "Short Description",

--- a/pythx/cli/utils.py
+++ b/pythx/cli/utils.py
@@ -145,7 +145,7 @@ def get_source_location_by_offset(filename, offset):
     overall = 0
     line_ctr = 0
     if not path.exists(filename):
-        LOGGER.warning(f"Could not find file {filename}")
+        LOGGER.warning("Could not find file %s", filename)
         return 0, 0
     with open(filename) as f:
         for line in f:

--- a/pythx/cli/utils.py
+++ b/pythx/cli/utils.py
@@ -73,6 +73,7 @@ def recover_client(config_path, staging=False, exit_on_missing=False, no_cache=F
     :param config_path: The configuration file's path
     :param staging: A boolean to denote whether to use staging or not
     :param exit_on_missing: Return if the file is missing
+    :param no_cache: Disable the API result cache
     :return:
     """
     if not path.isfile(config_path):

--- a/pythx/cli/utils.py
+++ b/pythx/cli/utils.py
@@ -3,6 +3,9 @@
 import json
 import sys
 from os import environ, path
+from distutils import spawn
+from subprocess import check_output
+
 
 import click
 from pythx.api import Client

--- a/pythx/cli/utils.py
+++ b/pythx/cli/utils.py
@@ -2,17 +2,16 @@
 
 import json
 import sys
-from os import environ, path
+from collections import defaultdict
 from copy import copy
 from distutils import spawn
+from os import environ, path
 from subprocess import check_output
-from collections import defaultdict
-from tabulate import tabulate
-
 
 import click
 from pythx.api import Client
 from pythx.cli.logger import LOGGER
+from tabulate import tabulate
 
 CONFIG_KEYS = ("access", "refresh", "username", "password")
 
@@ -92,7 +91,12 @@ def recover_client(config_path, staging=False, exit_on_missing=False, no_cache=F
             hide_input=True,
             default="trial",
         )
-        c = Client(eth_address=eth_address, password=password, staging=staging, no_cache=no_cache)
+        c = Client(
+            eth_address=eth_address,
+            password=password,
+            staging=staging,
+            no_cache=no_cache,
+        )
         c.login()
         update_config(config_path=config_path, client=c)
     else:
@@ -198,9 +202,7 @@ def echo_report_as_table(resp):
         for offset, _, file_idx in source_locs:
             if resp.source_list and file_idx >= 0:
                 filename = resp.source_list[file_idx]
-                line = get_source_location_by_offset(
-                    filename, int(offset)
-                )
+                line = get_source_location_by_offset(filename, int(offset))
             else:
                 filename = "Unknown"
                 line = "Unknown"
@@ -214,12 +216,7 @@ def echo_report_as_table(resp):
             tabulate(
                 data,
                 tablefmt="fancy_grid",
-                headers=(
-                    "Line",
-                    "SWC Title",
-                    "Severity",
-                    "Short Description",
-                ),
+                headers=("Line", "SWC Title", "Severity", "Short Description"),
             )
         )
 

--- a/pythx/cli/utils.py
+++ b/pythx/cli/utils.py
@@ -3,6 +3,7 @@
 import json
 import sys
 from os import environ, path
+from copy import copy
 from distutils import spawn
 from subprocess import check_output
 from collections import defaultdict
@@ -222,3 +223,20 @@ def echo_report_as_table(resp):
                 ),
             )
         )
+
+
+def zero_srcmap_indices(src_map: str) -> str:
+    """Zero the source map file index entries.
+
+    :param src_map: The source map string to process
+    :return: The processed source map string
+    """
+    entries = src_map.split(";")
+    new_entries = copy(entries)
+    for i, entry in enumerate(entries):
+        fields = entry.split(":")
+        if len(fields) > 2 and fields[2] not in ("-1", ""):
+            # file index is in entry, needs fixing
+            fields[2] = "0"
+            new_entries[i] = ":".join(fields)
+    return ";".join(new_entries)

--- a/pythx/cli/utils.py
+++ b/pythx/cli/utils.py
@@ -151,7 +151,6 @@ def get_source_location_by_offset(filename, offset):
     line_ctr = 0
     if not path.exists(filename):
         LOGGER.warning("Could not find file %s", filename)
-        return 0
     with open(filename) as f:
         for line in f:
             line_ctr += 1

--- a/pythx/cli/utils.py
+++ b/pythx/cli/utils.py
@@ -1,0 +1,172 @@
+"""This module contains helper functions for config files and Client recovery."""
+
+import json
+import sys
+from os import environ, path
+
+import click
+from pythx.api import Client
+from pythx.cli.logger import LOGGER
+
+CONFIG_KEYS = ("access", "refresh", "username", "password")
+
+
+def parse_config(config_path, tokens_required=False):
+    """Recover the user configuration file.
+
+    This file holds their most recent access and refresh JWT tokens. It allows PythX to
+    restore the user's login state across executions.
+
+    :param config_path: The configuration file's path
+    :param tokens_required: Raise an error if the tokens are required but missing
+    :return:
+    """
+    with open(config_path, "r") as config_f:
+        config = json.load(config_f)
+    keys_present = all(k in config for k in CONFIG_KEYS)
+    if not (type(config) == dict and keys_present):
+        click.echo(
+            "Malformed config file at {} doesn't contain required keys {}".format(
+                config_path, CONFIG_KEYS
+            )
+        )
+        sys.exit(1)
+    if tokens_required and not (config["access"] and config["refresh"]):
+        click.echo(
+            "Malformed config file at {} does not contain access and refresh token".format(
+                config_path
+            )
+        )
+        sys.exit(1)
+    return config
+
+
+def update_config(config_path, client):
+    """Update the user configuration file with the latest login data.
+
+    The stored data encompasses the API password, the user's Ethereum address, and the
+    latest access and refresh tokens.
+
+    :param config_path: The configuration file's path
+    :param client: The client instance to get the latest information from
+    """
+    with open(config_path, "w+") as config_f:
+        json.dump(
+            {
+                "username": client.eth_address,
+                "password": client.password,
+                "access": client.access_token,
+                "refresh": client.refresh_token,
+            },
+            config_f,
+        )
+
+
+def recover_client(config_path, staging=False, exit_on_missing=False):
+    """A simple helper method to recover a client instance based on a user config.
+
+    :param config_path: The configuration file's path
+    :param staging: A boolean to denote whether to use staging or not
+    :param exit_on_missing: Return if the file is missing
+    :return:
+    """
+    if not path.isfile(config_path):
+        if exit_on_missing:
+            return None
+        # config doesn't exist - assume first use
+        eth_address = environ.get("PYTHX_USERNAME") or click.prompt(
+            "Please enter your Ethereum address",
+            type=click.STRING,
+            default="0x0000000000000000000000000000000000000000",
+        )
+        password = environ.get("PYTHX_PASSWORD") or click.prompt(
+            "Please enter your MythX password",
+            type=click.STRING,
+            hide_input=True,
+            default="trial",
+        )
+        c = Client(eth_address=eth_address, password=password, staging=staging)
+        c.login()
+        update_config(config_path=config_path, client=c)
+    else:
+        config = parse_config(config_path, tokens_required=True)
+        c = Client(
+            eth_address=config["username"],
+            password=config["password"],
+            access_token=config["access"],
+            refresh_token=config["refresh"],
+            staging=staging,
+        )
+    return c
+
+
+def ps_core(config, staging, number):
+    """A helper method to retrieve data from the analysis list endpoint.
+
+    This functionality is used in the :code:`pythx ps`, as well as the :code:`pythx top`
+    subcommands.
+
+    :param config: The configuration file's path
+    :param staging: Boolean to denote whether to use the MythX staging deployment
+    :param number: The number of analyses to retrieve
+    :return: The API response as AnalysisList domain model
+    """
+    c = recover_client(config_path=config, staging=staging)
+    if c.eth_address == "0x0000000000000000000000000000000000000000":
+        click.echo(
+            (
+                "This functionality is only available to registered users. "
+                "Head over to https://mythx.io/ and register a free account to "
+                "list your past analyses. Alternatively, you can look up the "
+                "status of a specific job by calling 'pythx status <uuid>'."
+            )
+        )
+        sys.exit(0)
+    resp = c.analysis_list()
+    # TODO: paginate if too few analyses
+    resp.analyses = resp.analyses[: number + 1]
+    update_config(config_path=config, client=c)
+    return resp
+
+
+def get_source_location_by_offset(filename, offset):
+    """Retrieve the Solidity source file's location based on the source map offset.
+
+    :param filename: The Solidity file to analyze
+    :param offset: The source map's offset
+    :return: The line and column number
+    """
+    overall = 0
+    line_ctr = 0
+    with open(filename) as f:
+        for line in f:
+            line_ctr += 1
+            overall += len(line)
+            if overall >= offset:
+                return line_ctr, overall - offset
+    LOGGER.error(
+        "Error finding the source location in {} for offset {}".format(filename, offset)
+    )
+    sys.exit(1)
+
+
+def compile_from_source(source_path: str, solc_path: str = None):
+    """A simple wrapper around solc to compile Solidity source code.
+
+    :param source_path: The source file's path
+    :param solc_path: The path to the solc compiler
+    :return: The parsed solc compiler JSON output
+    """
+    solc_path = spawn.find_executable("solc") if solc_path is None else solc_path
+    if solc_path is None:
+        # user solc path invalid or no default "solc" command found
+        click.echo("Invalid solc path. Please make sure solc is on your PATH.")
+        sys.exit(1)
+    solc_command = [
+        solc_path,
+        "--combined-json",
+        "ast,bin,bin-runtime,srcmap,srcmap-runtime",
+        source_path,
+    ]
+    output = check_output(solc_command)
+    return json.loads(output)

--- a/pythx/middleware/analysiscache.py
+++ b/pythx/middleware/analysiscache.py
@@ -15,7 +15,7 @@ class AnalysisCacheMiddleware(BaseMiddleware):
     """
 
     def __init__(self, no_cache=False):
-        LOGGER.debug(f"Initializing with no_cache={no_cache}")
+        LOGGER.debug("Initializing with no_cache=%s", no_cache)
         self.no_cache = no_cache
 
     def process_request(self, req):
@@ -31,7 +31,7 @@ class AnalysisCacheMiddleware(BaseMiddleware):
         :return: The request's data dictionary, with the :code:`noCacheLookup` field filled in
         """
         if req["method"] == "POST" and req["url"].endswith("/analyses"):
-            LOGGER.debug(f"Adding noCacheLookup={self.no_cache}")
+            LOGGER.debug("Adding noCacheLookup=%s", self.no_cache)
             req["payload"]["noCacheLookup"] = self.no_cache
         return req
 

--- a/pythx/middleware/analysiscache.py
+++ b/pythx/middleware/analysiscache.py
@@ -1,0 +1,48 @@
+"""This module contains a middleware to fill the :code:`clientToolName` field."""
+
+import logging
+
+from pythx.middleware.base import BaseMiddleware
+
+LOGGER = logging.getLogger("AnalysisCacheMiddleware")
+
+
+class AnalysisCacheMiddleware(BaseMiddleware):
+    """This middleware fills the :code:`noCacheLookup` field when submitting a new analysis job.
+
+    This means that only :code:`process_request` carries business logic, while
+    :code:`process_response` returns the input response object right away without touching it.
+    """
+
+    def __init__(self, no_cache):
+        LOGGER.debug("Initializing")
+        self.no_cache = no_cache
+
+    def process_request(self, req):
+        """Add the :code:`noCacheLookup` field if the request we are making is the submission
+        of a new analysis job.
+
+        Because we execute the middleware on the request data dictionary, we cannot simply
+        match the domain model type here. However, based on the endpoint and the request
+        method we can determine that a new job has been submitted. In any other case, we
+        return the request right away without touching it.
+
+        :param req: The request's data dictionary
+        :return: The request's data dictionary, with the :code:`noCacheLookup` field filled in
+        """
+        if req["method"] == "POST" and req["url"].endswith("/analyses"):
+            LOGGER.debug(f"Adding noCacheLookup={self.no_cache}")
+            req["payload"]["noCacheLookup"] = self.no_cache
+        return req
+
+    def process_response(self, resp):
+        """This method is irrelevant for adding our tool name data, so we don't do anything here.
+
+        We still have to define it, though. Otherwise when calling the abstract base class'
+        :code:`process_response` method, we will encounter an exception.
+
+        :param resp: The response domain model
+        :return: The very same response domain model
+        """
+        LOGGER.debug("Forwarding the response without any action")
+        return resp

--- a/pythx/middleware/analysiscache.py
+++ b/pythx/middleware/analysiscache.py
@@ -14,8 +14,8 @@ class AnalysisCacheMiddleware(BaseMiddleware):
     :code:`process_response` returns the input response object right away without touching it.
     """
 
-    def __init__(self, no_cache):
-        LOGGER.debug("Initializing")
+    def __init__(self, no_cache=False):
+        LOGGER.debug(f"Initializing with no_cache={no_cache}")
         self.no_cache = no_cache
 
     def process_request(self, req):

--- a/pythx/models/request/analysis_list.py
+++ b/pythx/models/request/analysis_list.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from typing import Any, Dict
 
 import dateutil.parser
-
 from pythx.models.exceptions import RequestValidationError
 from pythx.models.request.base import BaseRequest
 

--- a/pythx/models/request/base.py
+++ b/pythx/models/request/base.py
@@ -5,7 +5,6 @@ import json
 import logging
 
 import jsonschema
-
 from pythx.models.exceptions import RequestValidationError
 
 LOGGER = logging.getLogger(__name__)

--- a/pythx/models/request/base.py
+++ b/pythx/models/request/base.py
@@ -52,7 +52,8 @@ class BaseRequest(abc.ABC):
         parsed = json.loads(json_str)
         return cls.from_dict(parsed)
 
-    @abc.abstractclassmethod
+    @classmethod
+    @abc.abstractmethod
     def from_dict(cls, d: dict):
         """An abstract method to construct the given domain model from a Python dict instance.
 
@@ -77,7 +78,8 @@ class BaseRequest(abc.ABC):
         """
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def payload(self):
         """An abstract property returning the request's payload data.
 
@@ -85,7 +87,8 @@ class BaseRequest(abc.ABC):
         """
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def headers(self):
         """An abstract property returning additional request headers.
 
@@ -93,7 +96,8 @@ class BaseRequest(abc.ABC):
         """
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def parameters(self):
         """An abstract property returning additional URL parameters
 
@@ -101,7 +105,8 @@ class BaseRequest(abc.ABC):
         """
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def method(self):
         """An abstract property returning the HTTP method to perform.
 

--- a/pythx/models/request/oas.py
+++ b/pythx/models/request/oas.py
@@ -8,7 +8,7 @@ class OASRequest(BaseRequest):
     """Perform an API request that gets the OpenAPI spec."""
 
     def __init__(self, mode="yaml"):
-        if not mode in ("yaml", "html"):
+        if mode not in ("yaml", "html"):
             raise RequestValidationError("'mode' must be one of {html,yaml}")
         self.mode = mode
 

--- a/pythx/models/request/schema/analysis-submission.json
+++ b/pythx/models/request/schema/analysis-submission.json
@@ -38,15 +38,7 @@
                         {
                             "required": ["ast"]
                         }
-                    ],
-                    "properties": {
-                        "source": {
-                            "type": "string"
-                        },
-                        "ast": {
-                            "type": "string"
-                        }
-                    }
+                    ]
                 }
             },
             "additionalProperties": false

--- a/pythx/models/response/analysis.py
+++ b/pythx/models/response/analysis.py
@@ -3,7 +3,6 @@
 from enum import Enum
 
 from inflection import underscore
-
 from pythx.models.response.base import BaseResponse
 from pythx.models.util import deserialize_api_timestamp, serialize_api_timestamp
 

--- a/pythx/models/response/base.py
+++ b/pythx/models/response/base.py
@@ -52,7 +52,8 @@ class BaseResponse(abc.ABC):
         parsed = json.loads(json_str)
         return cls.from_dict(parsed)
 
-    @abc.abstractclassmethod
+    @classmethod
+    @abc.abstractmethod
     def from_dict(cls, d: dict):
         """An abstract method to construct the given domain model from a Python dict instance.
 

--- a/pythx/models/response/base.py
+++ b/pythx/models/response/base.py
@@ -5,7 +5,6 @@ import json
 import logging
 
 import jsonschema
-
 from pythx.models.exceptions import ResponseValidationError
 
 LOGGER = logging.getLogger(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ inflection==0.3.1
 PyJWT==1.7.1
 tabulate==0.8.3
 jsonschema==3.0.1
+requests==2.21.0

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 import dateutil.parser
-
 from pythx.models.request import (
     AnalysisListRequest,
     AnalysisStatusRequest,

--- a/tests/common.py
+++ b/tests/common.py
@@ -394,3 +394,12 @@ DETECTED_ISSUES_RESPONSE_OBJECT = DetectedIssuesResponse(
     source_list=SOURCE_LIST,
     meta_data={},
 )
+
+def generate_request_dict(req):
+    return {
+        "method": req.method,
+        "payload": req.payload,
+        "params": req.parameters,
+        "headers": req.headers,
+        "url": "https://test.com/" + req.endpoint,
+    }

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -3,7 +3,6 @@ from copy import copy
 
 import dateutil.parser
 import pytest
-
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import Analysis, AnalysisStatus
 from pythx.models.util import deserialize_api_timestamp, serialize_api_timestamp

--- a/tests/test_analysis_list_request.py
+++ b/tests/test_analysis_list_request.py
@@ -2,7 +2,6 @@ import json
 
 import dateutil.parser
 import pytest
-
 from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import AnalysisListRequest
 

--- a/tests/test_analysis_list_response.py
+++ b/tests/test_analysis_list_response.py
@@ -2,7 +2,6 @@ import json
 from copy import deepcopy
 
 import pytest
-
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import AnalysisListResponse
 from pythx.models.response.analysis import Analysis

--- a/tests/test_analysis_status_request.py
+++ b/tests/test_analysis_status_request.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-
 from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import AnalysisStatusRequest
 

--- a/tests/test_analysis_status_response.py
+++ b/tests/test_analysis_status_response.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import Analysis, AnalysisStatusResponse
 from pythx.models.util import serialize_api_timestamp

--- a/tests/test_analysis_submission_request.py
+++ b/tests/test_analysis_submission_request.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-
 from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import AnalysisSubmissionRequest
 

--- a/tests/test_analysis_submission_response.py
+++ b/tests/test_analysis_submission_response.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import Analysis, AnalysisSubmissionResponse
 from pythx.models.util import serialize_api_timestamp

--- a/tests/test_api_handler.py
+++ b/tests/test_api_handler.py
@@ -3,7 +3,6 @@ from datetime import datetime
 
 import dateutil.parser
 import pytest
-
 from pythx import config
 from pythx.api.handler import APIHandler
 from pythx.middleware.base import BaseMiddleware

--- a/tests/test_auth_login_request.py
+++ b/tests/test_auth_login_request.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-
 from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import AuthLoginRequest
 

--- a/tests/test_auth_login_response.py
+++ b/tests/test_auth_login_response.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import AuthLoginResponse
 

--- a/tests/test_auth_logout_request.py
+++ b/tests/test_auth_logout_request.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-
 from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import AuthLogoutRequest
 

--- a/tests/test_auth_logout_response.py
+++ b/tests/test_auth_logout_response.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import AuthLogoutResponse
 

--- a/tests/test_auth_refresh_request.py
+++ b/tests/test_auth_refresh_request.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-
 from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import AuthRefreshRequest
 

--- a/tests/test_auth_refresh_response.py
+++ b/tests/test_auth_refresh_response.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import AuthRefreshResponse
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,9 +4,8 @@ from datetime import datetime, timedelta
 
 import jwt
 import pytest
-from dateutil.tz import tzutc
-
 import pythx.models.response as respmodels
+from dateutil.tz import tzutc
 from pythx import config
 from pythx.api import APIHandler, Client
 from pythx.models.exceptions import PythXAPIError, RequestValidationError

--- a/tests/test_client_tool_name_middleware.py
+++ b/tests/test_client_tool_name_middleware.py
@@ -1,5 +1,4 @@
 import pytest
-
 from pythx.middleware.toolname import ClientToolNameMiddleware
 
 from . import common as testdata

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,4 @@
 import pytest
-
 from pythx import config
 from pythx.conf.base import PythXConfig
 

--- a/tests/test_detected_issues_request.py
+++ b/tests/test_detected_issues_request.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-
 from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import DetectedIssuesRequest
 

--- a/tests/test_detected_issues_response.py
+++ b/tests/test_detected_issues_response.py
@@ -2,7 +2,6 @@ import json
 from copy import deepcopy
 
 import pytest
-
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import (
     DetectedIssuesResponse,

--- a/tests/test_issue.py
+++ b/tests/test_issue.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import (
     Issue,

--- a/tests/test_model_validator_errors.py
+++ b/tests/test_model_validator_errors.py
@@ -1,5 +1,4 @@
 import pytest
-
 from pythx.models import request as reqmodels
 from pythx.models import response as respmodels
 from pythx.models.exceptions import RequestValidationError, ResponseValidationError

--- a/tests/test_nocache_middleware.py
+++ b/tests/test_nocache_middleware.py
@@ -4,90 +4,105 @@ from pythx.middleware.analysiscache import AnalysisCacheMiddleware
 
 from . import common as testdata
 
-DEFAULT_CTN_MIDDLEWARE = ClientToolNameMiddleware()
-CUSTOM_CTN_MIDDLEWARE = ClientToolNameMiddleware(name="test")
+
+FALSE_CACHE_MIDDLEWARE = AnalysisCacheMiddleware(no_cache=False)
+TRUE_CACHE_MIDDLEWARE = AnalysisCacheMiddleware(no_cache=True)
 
 
 @pytest.mark.parametrize(
-    "middleware,request_dict,name_added",
+    "middleware,request_dict,flag_added,lookup_value",
     [
         (
-            DEFAULT_CTN_MIDDLEWARE,
+            TRUE_CACHE_MIDDLEWARE,
             testdata.generate_request_dict(testdata.ANALYSIS_LIST_REQUEST_OBJECT),
             False,
+            True
         ),
         (
-            DEFAULT_CTN_MIDDLEWARE,
+            TRUE_CACHE_MIDDLEWARE,
             testdata.generate_request_dict(testdata.DETECTED_ISSUES_REQUEST_OBJECT),
             False,
+            True
         ),
         (
-            DEFAULT_CTN_MIDDLEWARE,
+            TRUE_CACHE_MIDDLEWARE,
             testdata.generate_request_dict(testdata.ANALYSIS_STATUS_REQUEST_OBJECT),
             False,
+            True
         ),
         (
-            DEFAULT_CTN_MIDDLEWARE,
+            TRUE_CACHE_MIDDLEWARE,
             testdata.generate_request_dict(testdata.ANALYSIS_SUBMISSION_REQUEST_OBJECT),
             True,
+            True
         ),
         (
-            DEFAULT_CTN_MIDDLEWARE,
+            TRUE_CACHE_MIDDLEWARE,
             testdata.generate_request_dict(testdata.LOGIN_REQUEST_OBJECT),
             False,
+            True
         ),
         (
-            DEFAULT_CTN_MIDDLEWARE,
+            TRUE_CACHE_MIDDLEWARE,
             testdata.generate_request_dict(testdata.LOGOUT_REQUEST_OBJECT),
             False,
+            True
         ),
         (
-            DEFAULT_CTN_MIDDLEWARE,
+            TRUE_CACHE_MIDDLEWARE,
             testdata.generate_request_dict(testdata.REFRESH_REQUEST_OBJECT),
             False,
+            True
         ),
         (
-            CUSTOM_CTN_MIDDLEWARE,
+            FALSE_CACHE_MIDDLEWARE,
             testdata.generate_request_dict(testdata.ANALYSIS_LIST_REQUEST_OBJECT),
             False,
+            False,
         ),
         (
-            CUSTOM_CTN_MIDDLEWARE,
+            FALSE_CACHE_MIDDLEWARE,
             testdata.generate_request_dict(testdata.DETECTED_ISSUES_REQUEST_OBJECT),
             False,
+            False,
         ),
         (
-            CUSTOM_CTN_MIDDLEWARE,
+            FALSE_CACHE_MIDDLEWARE,
             testdata.generate_request_dict(testdata.ANALYSIS_STATUS_REQUEST_OBJECT),
             False,
+            False,
         ),
         (
-            CUSTOM_CTN_MIDDLEWARE,
+            FALSE_CACHE_MIDDLEWARE,
             testdata.generate_request_dict(testdata.ANALYSIS_SUBMISSION_REQUEST_OBJECT),
             True,
+            False,
         ),
         (
-            CUSTOM_CTN_MIDDLEWARE,
+            FALSE_CACHE_MIDDLEWARE,
             testdata.generate_request_dict(testdata.LOGIN_REQUEST_OBJECT),
             False,
-        ),
-        (
-            CUSTOM_CTN_MIDDLEWARE,
-            testdata.generate_request_dict(testdata.LOGOUT_REQUEST_OBJECT),
             False,
         ),
         (
-            CUSTOM_CTN_MIDDLEWARE,
+            FALSE_CACHE_MIDDLEWARE,
+            testdata.generate_request_dict(testdata.LOGOUT_REQUEST_OBJECT),
+            False,
+            False,
+        ),
+        (
+            FALSE_CACHE_MIDDLEWARE,
             testdata.generate_request_dict(testdata.REFRESH_REQUEST_OBJECT),
+            False,
             False,
         ),
     ],
 )
-def test_request_dicts(middleware, request_dict, name_added):
+def test_request_dicts(middleware, request_dict, flag_added, lookup_value):
     new_request = middleware.process_request(request_dict)
-    if name_added:
-        assert new_request["payload"].get("clientToolName") == middleware.name
-        del new_request["payload"]["clientToolName"]
+    if flag_added:
+        assert new_request["payload"].get("noCacheLookup") == lookup_value
+        del new_request["payload"]["noCacheLookup"]
 
     # rest of the result should stay the same
     assert request_dict == new_request
@@ -96,20 +111,20 @@ def test_request_dicts(middleware, request_dict, name_added):
 @pytest.mark.parametrize(
     "middleware,resp_obj",
     [
-        (DEFAULT_CTN_MIDDLEWARE, testdata.ANALYSIS_LIST_RESPONSE_OBJECT),
-        (DEFAULT_CTN_MIDDLEWARE, testdata.DETECTED_ISSUES_RESPONSE_OBJECT),
-        (DEFAULT_CTN_MIDDLEWARE, testdata.ANALYSIS_STATUS_RESPONSE_OBJECT),
-        (DEFAULT_CTN_MIDDLEWARE, testdata.ANALYSIS_SUBMISSION_RESPONSE_OBJECT),
-        (DEFAULT_CTN_MIDDLEWARE, testdata.LOGIN_RESPONSE_OBJECT),
-        (DEFAULT_CTN_MIDDLEWARE, testdata.LOGOUT_RESPONSE_OBJECT),
-        (DEFAULT_CTN_MIDDLEWARE, testdata.REFRESH_RESPONSE_OBJECT),
-        (CUSTOM_CTN_MIDDLEWARE, testdata.ANALYSIS_LIST_RESPONSE_OBJECT),
-        (CUSTOM_CTN_MIDDLEWARE, testdata.DETECTED_ISSUES_RESPONSE_OBJECT),
-        (CUSTOM_CTN_MIDDLEWARE, testdata.ANALYSIS_STATUS_RESPONSE_OBJECT),
-        (CUSTOM_CTN_MIDDLEWARE, testdata.ANALYSIS_SUBMISSION_RESPONSE_OBJECT),
-        (CUSTOM_CTN_MIDDLEWARE, testdata.LOGIN_RESPONSE_OBJECT),
-        (CUSTOM_CTN_MIDDLEWARE, testdata.LOGOUT_RESPONSE_OBJECT),
-        (CUSTOM_CTN_MIDDLEWARE, testdata.REFRESH_RESPONSE_OBJECT),
+        (FALSE_CACHE_MIDDLEWARE, testdata.ANALYSIS_LIST_RESPONSE_OBJECT),
+        (FALSE_CACHE_MIDDLEWARE, testdata.DETECTED_ISSUES_RESPONSE_OBJECT),
+        (FALSE_CACHE_MIDDLEWARE, testdata.ANALYSIS_STATUS_RESPONSE_OBJECT),
+        (FALSE_CACHE_MIDDLEWARE, testdata.ANALYSIS_SUBMISSION_RESPONSE_OBJECT),
+        (FALSE_CACHE_MIDDLEWARE, testdata.LOGIN_RESPONSE_OBJECT),
+        (FALSE_CACHE_MIDDLEWARE, testdata.LOGOUT_RESPONSE_OBJECT),
+        (FALSE_CACHE_MIDDLEWARE, testdata.REFRESH_RESPONSE_OBJECT),
+        (TRUE_CACHE_MIDDLEWARE, testdata.ANALYSIS_LIST_RESPONSE_OBJECT),
+        (TRUE_CACHE_MIDDLEWARE, testdata.DETECTED_ISSUES_RESPONSE_OBJECT),
+        (TRUE_CACHE_MIDDLEWARE, testdata.ANALYSIS_STATUS_RESPONSE_OBJECT),
+        (TRUE_CACHE_MIDDLEWARE, testdata.ANALYSIS_SUBMISSION_RESPONSE_OBJECT),
+        (TRUE_CACHE_MIDDLEWARE, testdata.LOGIN_RESPONSE_OBJECT),
+        (TRUE_CACHE_MIDDLEWARE, testdata.LOGOUT_RESPONSE_OBJECT),
+        (TRUE_CACHE_MIDDLEWARE, testdata.REFRESH_RESPONSE_OBJECT),
     ],
 )
 def test_response_models(middleware, resp_obj):

--- a/tests/test_oas_request.py
+++ b/tests/test_oas_request.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-
 from pythx.models.exceptions import RequestValidationError
 from pythx.models.request import OASRequest
 

--- a/tests/test_oas_response.py
+++ b/tests/test_oas_response.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import OASResponse
 

--- a/tests/test_util_methods.py
+++ b/tests/test_util_methods.py
@@ -2,7 +2,6 @@ from datetime import datetime
 
 import pytest
 from dateutil.tz import tzutc
-
 from pythx.models.util import (
     deserialize_api_timestamp,
     dict_delete_none_fields,

--- a/tests/test_version_request.py
+++ b/tests/test_version_request.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-
 from pythx.models.request import VersionRequest
 
 from . import common as testdata

--- a/tests/test_version_response.py
+++ b/tests/test_version_response.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-
 from pythx.models.exceptions import ResponseValidationError
 from pythx.models.response import VersionResponse
 


### PR DESCRIPTION
This allows the user to run `pythx truffle` in the root of a complied truffle project. The truffle-generated artifacts files are parsed by PythX and submitted to MythX. After a simple waiting routine (sequential polling), the finished issue reports are fetched and displayed one by one.

Fixes #14 and #15