### PR TITLE
Upgrade PyJWT 1.7.1 -> 2.4.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,7 @@
+-----
+
+This fork has an upgraded PyJWT version: 1.7.1 -> 2.4.0
+
 =====
 PythX
 =====

--- a/pythx/api/client.py
+++ b/pythx/api/client.py
@@ -141,7 +141,7 @@ class Client:
         :param token: The JWT to perform the check on
         :return: The UTC expiration datetime object
         """
-        return datetime.utcfromtimestamp((jwt.decode(token, verify=False)["exp"]))
+        return datetime.utcfromtimestamp((jwt.decode(token, algorithms=["HS256"], options={"verify_signature": False})["exp"]))
 
     def assert_authentication(self) -> None:
         """Make sure the user is authenticated.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil==2.8.1
 inflection==0.5.1
-PyJWT==1.7.1
+PyJWT==2.4.0
 requests==2.25.1
 mythx-models==2.2.0


### PR DESCRIPTION
Since PyJWT==1.7.1 is insecure:
https://vuldb.com/?id.200637

I've adjusted the Client to work with the new version. Without my code, there were 16 failed tests, upgrading would add another 2 which I fixed.